### PR TITLE
fix(resource/katapult_virtual_machine): validate package downgrades at plan time

### DIFF
--- a/internal/provider/resource_virtual_machine.go
+++ b/internal/provider/resource_virtual_machine.go
@@ -207,9 +207,9 @@ The Virtual Machine resource allows you to create and manage Virtual Machines in
 }
 
 func resourceVirtualMachineCustomizeDiff(
-	_ context.Context,
+	ctx context.Context,
 	d *schema.ResourceDiff,
-	_ interface{},
+	meta interface{},
 ) error {
 	if d.HasChange("ip_address_ids") {
 		err := d.SetNewComputed("ip_addresses")
@@ -225,7 +225,82 @@ func resourceVirtualMachineCustomizeDiff(
 		}
 	}
 
+	return validateVirtualMachinePackageChange(ctx, d, meta)
+}
+
+// validateVirtualMachinePackageChange fails the plan when a package change
+// would downgrade a running Virtual Machine, as Katapult requires the VM to
+// be stopped before its vCPU count or memory can be reduced.
+func validateVirtualMachinePackageChange(
+	ctx context.Context,
+	d *schema.ResourceDiff,
+	meta interface{},
+) error {
+	if d.Id() == "" ||
+		!d.HasChange("package") ||
+		!d.NewValueKnown("package") {
+		return nil
+	}
+
+	m := meta.(*Meta)
+	pkgRef := d.Get("package").(string)
+
+	vm, _, err := m.Core.VirtualMachines.GetByID(ctx, d.Id())
+	if err != nil {
+		// A missing VM is handled by the regular plan/apply flow, so only
+		// unexpected errors should fail the plan.
+		if errors.Is(err, katapult.ErrNotFound) ||
+			errors.Is(err, core.ErrObjectInTrash) {
+			return nil
+		}
+
+		return fmt.Errorf(
+			"failed to fetch virtual machine details: %w", err,
+		)
+	}
+
+	if vm.Package == nil || vm.State != core.VirtualMachineStarted {
+		return nil
+	}
+
+	// Referencing the current package by its other format (ID vs permalink)
+	// is not a real package change, so there is nothing to validate.
+	if vm.Package.ID == pkgRef || vm.Package.Permalink == pkgRef {
+		return nil
+	}
+
+	newPkg, _, err := m.Core.VirtualMachinePackages.Get(
+		ctx, virtualMachinePackageRef(pkgRef),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to fetch new package details: %w", err)
+	}
+
+	if newPkg != nil &&
+		(newPkg.CPUCores < vm.Package.CPUCores ||
+			newPkg.MemoryInGB < vm.Package.MemoryInGB) {
+		return fmt.Errorf(
+			"cannot downgrade package while Virtual Machine is running: "+
+				"current package has %d vCPU(s) and %dGB memory, new "+
+				"package has %d vCPU(s) and %dGB memory. Stop the "+
+				"Virtual Machine before downgrading.",
+			vm.Package.CPUCores, vm.Package.MemoryInGB,
+			newPkg.CPUCores, newPkg.MemoryInGB,
+		)
+	}
+
 	return nil
+}
+
+// virtualMachinePackageRef builds a package ref from a user-provided value,
+// treating values with a "vmpkg_" prefix as IDs, and anything else as a
+// permalink.
+func virtualMachinePackageRef(value string) core.VirtualMachinePackageRef {
+	if strings.HasPrefix(value, "vmpkg_") {
+		return core.VirtualMachinePackageRef{ID: value}
+	}
+
+	return core.VirtualMachinePackageRef{Permalink: value}
 }
 
 //nolint:funlen,gocyclo
@@ -768,59 +843,35 @@ func resourceVirtualMachineUpdate(
 
 	if d.HasChange("package") {
 		pkgRef := d.Get("package").(string)
-		pkg := core.VirtualMachinePackageRef{}
-		if strings.HasPrefix(pkgRef, "vmpkg_") {
-			pkg.ID = pkgRef
-		} else {
-			pkg.Permalink = pkgRef
-		}
 
-		// Fetch current VM to check if running and get current package
 		currentVM, _, err := m.Core.VirtualMachines.GetByID(ctx, vm.ID)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
-		// Validate that downgrades aren't attempted while VM is running
-		if currentVM.State == "started" && currentVM.Package != nil {
-			newPkg, _, errVMPKG := m.Core.VirtualMachinePackages.Get(ctx, pkg)
-			if errVMPKG != nil {
-				return diag.FromErr(fmt.Errorf(
-					"failed to fetch new package details: %w", errVMPKG,
-				))
-			}
+		// The API rejects package changes to the VM's current package, so
+		// skip the call when the new value only references the current
+		// package by its other format (ID vs permalink). The read at the
+		// end of the update rewrites state in the configured format.
+		samePackage := currentVM.Package != nil &&
+			(currentVM.Package.ID == pkgRef ||
+				currentVM.Package.Permalink == pkgRef)
 
-			if newPkg != nil {
-				// Check if this is a downgrade (fewer vCPUs or memory)
-				if (newPkg.CPUCores < currentVM.Package.CPUCores) ||
-					(newPkg.MemoryInGB < currentVM.Package.MemoryInGB) {
-					return diag.Errorf(
-						"cannot downgrade package while Virtual Machine "+
-							"is running: current package has %d vCPU(s) "+
-							"and %dGB memory, new package has %d vCPU(s) "+
-							"and %dGB memory. Stop the Virtual Machine "+
-							"before downgrading.",
-						currentVM.Package.CPUCores,
-						currentVM.Package.MemoryInGB,
-						newPkg.CPUCores, newPkg.MemoryInGB,
-					)
-				}
-			}
-		}
-
-		task, _, err := m.Core.VirtualMachines.ChangePackage(
-			ctx, vm.Ref(), pkg,
-		)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		if task != nil {
-			err = waitForTaskCompletion(
-				ctx, m, d.Timeout(schema.TimeoutUpdate), task.ID,
+		if !samePackage {
+			task, _, err := m.Core.VirtualMachines.ChangePackage(
+				ctx, vm.Ref(), virtualMachinePackageRef(pkgRef),
 			)
 			if err != nil {
 				return diag.FromErr(err)
+			}
+
+			if task != nil {
+				err = waitForTaskCompletion(
+					ctx, m, d.Timeout(schema.TimeoutUpdate), task.ID,
+				)
+				if err != nil {
+					return diag.FromErr(err)
+				}
 			}
 		}
 	}

--- a/internal/provider/resource_virtual_machine.go
+++ b/internal/provider/resource_virtual_machine.go
@@ -954,7 +954,7 @@ func resourceVirtualMachineDelete(
 	}
 
 	if !stopped {
-		_, err = waitForVirtualMachineToStop(
+		err = waitForVirtualMachineToStop(
 			ctx, m, timeout, vm.Ref(),
 		)
 		if err != nil && !isErrNotFoundOrInTrash(err) {
@@ -1053,7 +1053,7 @@ func waitForVirtualMachineToStop(
 	m *Meta,
 	timeout time.Duration,
 	vmRef core.VirtualMachineRef,
-) (*core.VirtualMachine, error) {
+) error {
 	waiter := &retry.StateChangeConf{
 		Pending: []string{
 			string(core.VirtualMachineStarted),
@@ -1077,9 +1077,9 @@ func waitForVirtualMachineToStop(
 		ContinuousTargetOccurence: 1,
 	}
 
-	rawVM, err := waiter.WaitForStateContext(ctx)
+	_, err := waiter.WaitForStateContext(ctx)
 
-	return rawVM.(*core.VirtualMachine), err
+	return err
 }
 
 func normalizeVirtualMachinePackage(

--- a/internal/provider/resource_virtual_machine_test.go
+++ b/internal/provider/resource_virtual_machine_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jimeh/undent"
 	"github.com/krystal/go-katapult"
 	"github.com/krystal/go-katapult/core"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() { //nolint:gochecknoinits
@@ -1281,5 +1282,106 @@ func testAccCheckKatapultVirtualMachineDestroy(
 		}
 
 		return nil
+	}
+}
+
+func Test_normalizeVirtualMachinePackageForState(t *testing.T) {
+	pkg := &core.VirtualMachinePackage{
+		ID:        "vmpkg_YlqvfsKqZm6mpY4Y",
+		Permalink: "rock-3",
+	}
+
+	tests := []struct {
+		name       string
+		configured string
+		pkg        *core.VirtualMachinePackage
+		want       string
+	}{
+		{
+			name:       "nil package",
+			configured: "rock-3",
+			pkg:        nil,
+			want:       "",
+		},
+		{
+			name:       "configured with ID",
+			configured: "vmpkg_YlqvfsKqZm6mpY4Y",
+			pkg:        pkg,
+			want:       "vmpkg_YlqvfsKqZm6mpY4Y",
+		},
+		{
+			name:       "configured with permalink",
+			configured: "rock-3",
+			pkg:        pkg,
+			want:       "rock-3",
+		},
+		{
+			name:       "not configured (import)",
+			configured: "",
+			pkg:        pkg,
+			want:       "rock-3",
+		},
+		{
+			name:       "configured with ID, package has no ID",
+			configured: "vmpkg_YlqvfsKqZm6mpY4Y",
+			pkg:        &core.VirtualMachinePackage{Permalink: "rock-3"},
+			want:       "rock-3",
+		},
+		{
+			name:       "package has no permalink",
+			configured: "rock-3",
+			pkg: &core.VirtualMachinePackage{
+				ID: "vmpkg_YlqvfsKqZm6mpY4Y",
+			},
+			want: "vmpkg_YlqvfsKqZm6mpY4Y",
+		},
+		{
+			name:       "package has no ID or permalink",
+			configured: "rock-3",
+			pkg:        &core.VirtualMachinePackage{},
+			want:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeVirtualMachinePackageForState(
+				tt.configured, tt.pkg,
+			)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_virtualMachinePackageRef(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  core.VirtualMachinePackageRef
+	}{
+		{
+			name:  "ID",
+			value: "vmpkg_YlqvfsKqZm6mpY4Y",
+			want: core.VirtualMachinePackageRef{
+				ID: "vmpkg_YlqvfsKqZm6mpY4Y",
+			},
+		},
+		{
+			name:  "permalink",
+			value: "rock-3",
+			want:  core.VirtualMachinePackageRef{Permalink: "rock-3"},
+		},
+		{
+			name:  "empty",
+			value: "",
+			want:  core.VirtualMachinePackageRef{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := virtualMachinePackageRef(tt.value)
+
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }

--- a/internal/provider/resource_virtual_machine_test.go
+++ b/internal/provider/resource_virtual_machine_test.go
@@ -1373,8 +1373,8 @@ func TestAccKatapultVirtualMachine_update_network_speed_profile(t *testing.T) {
 // extractResourceAttr captures the value of a resource attribute into target
 // so it can be compared against in a later test step.
 func extractResourceAttr(
-	res string,
-	attr string,
+	res string, //nolint:unparam
+	attr string, //nolint:unparam
 	target *string,
 ) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -1412,7 +1412,7 @@ func stopVirtualMachine(tt *testTools, id string) {
 		require.NoError(tt.T, err, "stop virtual machine task failed")
 	}
 
-	_, err = waitForVirtualMachineToStop(tt.Ctx, tt.Meta, 5*time.Minute, ref)
+	err = waitForVirtualMachineToStop(tt.Ctx, tt.Meta, 5*time.Minute, ref)
 	require.NoError(tt.T, err, "virtual machine did not reach stopped state")
 }
 

--- a/internal/provider/resource_virtual_machine_test.go
+++ b/internal/provider/resource_virtual_machine_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/krystal/go-katapult"
 	"github.com/krystal/go-katapult/core"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() { //nolint:gochecknoinits
@@ -855,6 +856,180 @@ func TestAccKatapultVirtualMachine_update_package_downgrade_error(t *testing.T) 
 	})
 }
 
+func TestAccKatapultVirtualMachine_update_package_downgrade_stopped(t *testing.T) { //nolint:lll
+	tt := newTestTools(t)
+
+	name := tt.ResourceName()
+
+	// Capture the VM ID across steps so the second step can stop the VM
+	// outside of Terraform, and to assert the package change resizes the
+	// VM in place rather than destroying and recreating it.
+	var vmID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckKatapultVirtualMachineDestroy(tt),
+			testAccCheckKatapultIPDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: undent.Stringf(`
+					resource "katapult_legacy_ip" "web" {}
+
+					resource "katapult_virtual_machine" "base" {
+						name          = "%s"
+						hostname      = "%s"
+						package       = "rock-3"
+						disk_template = "ubuntu-18-04"
+						disk_template_options = {
+							install_agent = true
+						}
+						ip_address_ids = [katapult_legacy_ip.web.id]
+					}`,
+					name, name+"-host",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKatapultVirtualMachineExists(
+						tt, "katapult_virtual_machine.base",
+					),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base",
+						"package", "rock-3",
+					),
+					extractResourceAttr(
+						"katapult_virtual_machine.base", "id", &vmID,
+					),
+				),
+			},
+			{
+				// Downgrades are only permitted while the VM is stopped,
+				// so stop it outside of Terraform before applying.
+				PreConfig: func() {
+					stopVirtualMachine(tt, vmID)
+				},
+				Config: undent.Stringf(`
+					resource "katapult_legacy_ip" "web" {}
+
+					resource "katapult_virtual_machine" "base" {
+						name          = "%s"
+						hostname      = "%s"
+						package       = "rock-1"
+						disk_template = "ubuntu-18-04"
+						disk_template_options = {
+							install_agent = true
+						}
+						ip_address_ids = [katapult_legacy_ip.web.id]
+					}`,
+					name, name+"-host",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKatapultVirtualMachineExists(
+						tt, "katapult_virtual_machine.base",
+					),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base",
+						"package", "rock-1",
+					),
+					// The VM must keep the same ID; a package change is an
+					// in-place resize, not a destroy/recreate.
+					resource.TestCheckResourceAttrPtr(
+						"katapult_virtual_machine.base", "id", &vmID,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKatapultVirtualMachine_update_package_upgrade_stopped(t *testing.T) { //nolint:lll
+	tt := newTestTools(t)
+
+	name := tt.ResourceName()
+
+	// Capture the VM ID across steps so the second step can stop the VM
+	// outside of Terraform, and to assert the package change resizes the
+	// VM in place rather than destroying and recreating it.
+	var vmID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckKatapultVirtualMachineDestroy(tt),
+			testAccCheckKatapultIPDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: undent.Stringf(`
+					resource "katapult_legacy_ip" "web" {}
+
+					resource "katapult_virtual_machine" "base" {
+						name          = "%s"
+						hostname      = "%s"
+						package       = "rock-1"
+						disk_template = "ubuntu-18-04"
+						disk_template_options = {
+							install_agent = true
+						}
+						ip_address_ids = [katapult_legacy_ip.web.id]
+					}`,
+					name, name+"-host",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKatapultVirtualMachineExists(
+						tt, "katapult_virtual_machine.base",
+					),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base",
+						"package", "rock-1",
+					),
+					extractResourceAttr(
+						"katapult_virtual_machine.base", "id", &vmID,
+					),
+				),
+			},
+			{
+				// Upgrades are permitted while the VM is running, but must
+				// also work against a stopped VM.
+				PreConfig: func() {
+					stopVirtualMachine(tt, vmID)
+				},
+				Config: undent.Stringf(`
+					resource "katapult_legacy_ip" "web" {}
+
+					resource "katapult_virtual_machine" "base" {
+						name          = "%s"
+						hostname      = "%s"
+						package       = "rock-3"
+						disk_template = "ubuntu-18-04"
+						disk_template_options = {
+							install_agent = true
+						}
+						ip_address_ids = [katapult_legacy_ip.web.id]
+					}`,
+					name, name+"-host",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckKatapultVirtualMachineExists(
+						tt, "katapult_virtual_machine.base",
+					),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base",
+						"package", "rock-3",
+					),
+					// The VM must keep the same ID; a package change is an
+					// in-place resize, not a destroy/recreate.
+					resource.TestCheckResourceAttrPtr(
+						"katapult_virtual_machine.base", "id", &vmID,
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKatapultVirtualMachine_update_ips(t *testing.T) {
 	tt := newTestTools(t)
 
@@ -1217,6 +1392,28 @@ func extractResourceAttr(
 
 		return nil
 	}
+}
+
+// stopVirtualMachine stops a Virtual Machine outside of Terraform and waits
+// for it to reach the stopped state, allowing tests to exercise behavior
+// which requires a stopped VM, such as package downgrades.
+func stopVirtualMachine(tt *testTools, id string) {
+	tt.T.Helper()
+
+	ref := core.VirtualMachineRef{ID: id}
+
+	task, _, err := tt.Meta.Core.VirtualMachines.Stop(tt.Ctx, ref)
+	require.NoError(tt.T, err, "failed to stop virtual machine")
+
+	if task != nil {
+		err = waitForTaskCompletion(
+			tt.Ctx, tt.Meta, 5*time.Minute, task.ID,
+		)
+		require.NoError(tt.T, err, "stop virtual machine task failed")
+	}
+
+	_, err = waitForVirtualMachineToStop(tt.Ctx, tt.Meta, 5*time.Minute, ref)
+	require.NoError(tt.T, err, "virtual machine did not reach stopped state")
 }
 
 func testAccCheckKatapultVirtualMachineExists(

--- a/internal/provider/testdata/VirtualMachine_update_package.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_package.cassette.rand_id
@@ -1,1 +1,1 @@
-dhc8vwfhs97q
+rfdcmntu1cz7

--- a/internal/provider/testdata/VirtualMachine_update_package.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_package.cassette.yaml
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "998"
       X-Request-Id:
-      - cf13927f-5644-447e-b95b-ade31ef32024
+      - 3a192d41-1f49-4cda-a42f-da279f73bd42
     status: 200 OK
     code: 200
     duration: ""
@@ -57,7 +57,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"185-44-254-115.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"185-44-254-221.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -74,9 +74,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"7edf550acb5b9eacf56a0f026a5f5fd7"
+      - W/"c953535fc5b4c6bb15de03037a85f306"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -84,9 +84,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "995"
       X-Request-Id:
-      - 6413ab2f-1cb5-4746-bb04-64fdca6d6053
+      - da287bd3-d14c-40e5-a2b2-9cf72b4c7c4c
     status: 200 OK
     code: 200
     duration: ""
@@ -98,10 +98,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_pB9DjnTpH9xlHDZL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_nd0lMdcBDX7CqrtG
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"185-44-254-115.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"185-44-254-221.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -118,9 +118,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"1022305f8a891f5268911dcb07c10583"
+      - W/"31e1c1596c98404196bdc48de2eb1b62"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -128,9 +128,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "990"
       X-Request-Id:
-      - 88ce97eb-cf86-4743-828c-edb5c83cb2ab
+      - 727fcb75-796d-4622-9b66-1c15345b2be2
     status: 200 OK
     code: 200
     duration: ""
@@ -142,10 +142,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_pB9DjnTpH9xlHDZL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_nd0lMdcBDX7CqrtG
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"185-44-254-115.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"185-44-254-221.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -162,9 +162,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"1022305f8a891f5268911dcb07c10583"
+      - W/"31e1c1596c98404196bdc48de2eb1b62"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -172,15 +172,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "989"
       X-Request-Id:
-      - 7325b8af-66fc-4894-a88c-439e50a38113
+      - d800084b-f657-414c-9f0a-fa06146f9649
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-1</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_pB9DjnTpH9xlHDZL</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-package-dhc8vwfhs97q-host</Hostname></Hostname><Name>tf-acc-test-update-package-dhc8vwfhs97q</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-1</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_nd0lMdcBDX7CqrtG</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-package-rfdcmntu1cz7-host</Hostname></Hostname><Name>tf-acc-test-update-package-rfdcmntu1cz7</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -192,7 +192,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_3EauNaaroOUQu3KX","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_hvBRJIfTI20Tu2m5","state":"pending"},"virtual_machine_build":{"id":"vmbuild_hvBRJIfTI20Tu2m5","state":"pending"},"hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","annotations":[]}'
+    body: '{"task":{"id":"task_vIwrQ6YtlY5aSgNA","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_8pTJSCZGVj6sEq5E","state":"pending"},"virtual_machine_build":{"id":"vmbuild_8pTJSCZGVj6sEq5E","state":"pending"},"hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -207,9 +207,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:48 GMT
+      - Wed, 08 Jul 2026 18:42:40 GMT
       Etag:
-      - W/"0d25bc51a4494d9a8ca2894a4b1b8a60"
+      - W/"9dfe9721c85d789db3116fd5a901f8ad"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -217,9 +217,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "988"
       X-Request-Id:
-      - ab65c5a6-b87e-4e53-b000-eb1f8883a47e
+      - 4f58addc-7313-42af-889c-1f3e0013ea3f
     status: 201 Created
     code: 201
     duration: ""
@@ -231,17 +231,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_hvBRJIfTI20Tu2m5
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_8pTJSCZGVj6sEq5E
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_hvBRJIfTI20Tu2m5","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_8pTJSCZGVj6sEq5E","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.115\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-dhc8vwfhs97q-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-dhc8vwfhs97q\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-rfdcmntu1cz7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-rfdcmntu1cz7\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1780867127},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -254,9 +254,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:50 GMT
+      - Wed, 08 Jul 2026 18:42:42 GMT
       Etag:
-      - W/"23b66d49ca977cabc5938e42623c362e"
+      - W/"6a5882d1034f6c8d0758169630c3e910"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -264,9 +264,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "982"
       X-Request-Id:
-      - 15ce7956-4337-4e24-b68b-ea81321240ca
+      - bc057740-4efa-42ef-a08f-ac5fb34fd134
     status: 200 OK
     code: 200
     duration: ""
@@ -278,17 +278,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_hvBRJIfTI20Tu2m5
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_8pTJSCZGVj6sEq5E
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_hvBRJIfTI20Tu2m5","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_8pTJSCZGVj6sEq5E","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.115\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-dhc8vwfhs97q-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-dhc8vwfhs97q\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-rfdcmntu1cz7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-rfdcmntu1cz7\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1780867127},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -301,9 +301,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:55 GMT
+      - Wed, 08 Jul 2026 18:42:47 GMT
       Etag:
-      - W/"f40b14e27186f5eefd303b8a46b38837"
+      - W/"6a5882d1034f6c8d0758169630c3e910"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -311,9 +311,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "981"
+      - "979"
       X-Request-Id:
-      - 2d55d256-7d3a-4df0-b156-c03dbfe0e470
+      - 0db76a8f-16a5-4eaf-80e5-1fb99474a2c4
     status: 200 OK
     code: 200
     duration: ""
@@ -325,17 +325,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_hvBRJIfTI20Tu2m5
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_8pTJSCZGVj6sEq5E
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_hvBRJIfTI20Tu2m5","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_8pTJSCZGVj6sEq5E","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.115\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-dhc8vwfhs97q-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-dhc8vwfhs97q\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-rfdcmntu1cz7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-rfdcmntu1cz7\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1780867127},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -348,151 +348,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:05 GMT
+      - Wed, 08 Jul 2026 18:42:57 GMT
       Etag:
-      - W/"f40b14e27186f5eefd303b8a46b38837"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - c06da329-b167-47ee-bd7a-7a2c46d9520f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_hvBRJIfTI20Tu2m5
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_hvBRJIfTI20Tu2m5","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.115\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-dhc8vwfhs97q-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-dhc8vwfhs97q\u003c/Name\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1780867127},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:15 GMT
-      Etag:
-      - W/"f40b14e27186f5eefd303b8a46b38837"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 964a437d-5ed9-4927-a12b-d51f279ceee5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_hvBRJIfTI20Tu2m5
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_hvBRJIfTI20Tu2m5","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.115\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-dhc8vwfhs97q-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-dhc8vwfhs97q\u003c/Name\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1780867127},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:25 GMT
-      Etag:
-      - W/"ae9efc2f5c8881df49d01b0c15d7cc60"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "985"
-      X-Request-Id:
-      - db2f63ee-8128-4d1e-b8c6-a2ad307883b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:27 GMT
-      Etag:
-      - W/"966c722848737ce32ffc05eb54c8b693"
+      - W/"c0447cd61279e50ca332c3ed5fe57a60"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -502,7 +360,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "970"
       X-Request-Id:
-      - cd88634a-ce63-4b24-9295-8d3cf6e3cb01
+      - 5e3ef067-d763-4626-ac17-ff2680815b72
     status: 200 OK
     code: 200
     duration: ""
@@ -514,18 +372,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_8pTJSCZGVj6sEq5E
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_8pTJSCZGVj6sEq5E","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-rfdcmntu1cz7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-rfdcmntu1cz7\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -538,9 +395,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:32 GMT
+      - Wed, 08 Jul 2026 18:43:07 GMT
       Etag:
-      - W/"5045412370a20173429ac3ddb0a67421"
+      - W/"c0447cd61279e50ca332c3ed5fe57a60"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -548,9 +405,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "998"
       X-Request-Id:
-      - b5f736ab-ed35-4c6d-93bb-edf4bdf5e16a
+      - 31329105-87a2-4269-b614-ecbe3feeae17
     status: 200 OK
     code: 200
     duration: ""
@@ -562,18 +419,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_8pTJSCZGVj6sEq5E
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_8pTJSCZGVj6sEq5E","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-rfdcmntu1cz7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-rfdcmntu1cz7\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -586,9 +442,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:32 GMT
+      - Wed, 08 Jul 2026 18:43:17 GMT
       Etag:
-      - W/"5045412370a20173429ac3ddb0a67421"
+      - W/"c0447cd61279e50ca332c3ed5fe57a60"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -596,9 +452,152 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "960"
       X-Request-Id:
-      - abffaa62-6d90-44c7-9f6c-b8533d0cdd72
+      - d227a0e3-f73b-457c-940a-d7d591b0455d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_8pTJSCZGVj6sEq5E
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_8pTJSCZGVj6sEq5E","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-rfdcmntu1cz7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-rfdcmntu1cz7\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1783536159},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:27 GMT
+      Etag:
+      - W/"501a63e4e3edbbffdf427bcd61a349e3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 34616740-5ab9-4df7-be14-b7f7dd6eae34
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:29 GMT
+      Etag:
+      - W/"355d82723306e0442b5823e94ff7512f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - d28b9715-494a-4970-a877-f541ffbc7c30
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:29 GMT
+      Etag:
+      - W/"355d82723306e0442b5823e94ff7512f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "953"
+      X-Request-Id:
+      - 1fe9c285-9864-4023-9b6f-948869827ccb
     status: 200 OK
     code: 200
     duration: ""
@@ -608,12 +607,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q23NnxOlykfd6fBZ","name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.115/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wDt6ozD2seLndKdr","name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.221/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -628,9 +627,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:32 GMT
+      - Wed, 08 Jul 2026 18:43:29 GMT
       Etag:
-      - W/"22d2eb7b781e046556be69197abb6cc8"
+      - W/"9d891744d5badb1d535db510a7f9616c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -638,9 +637,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "952"
       X-Request-Id:
-      - 39ca1fc5-a865-4409-8c1d-4f4d8e4b8822
+      - 553c7bd5-110e-4e73-96e7-0d87be68f71b
     status: 200 OK
     code: 200
     duration: ""
@@ -650,12 +649,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -670,9 +669,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:32 GMT
+      - Wed, 08 Jul 2026 18:43:29 GMT
       Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -680,9 +679,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "951"
       X-Request-Id:
-      - 483b5cfc-9410-4438-b2e6-373de30da2e9
+      - 1f724a72-eb56-42d5-8440-f7a6defed412
     status: 200 OK
     code: 200
     duration: ""
@@ -694,12 +693,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -714,9 +713,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:32 GMT
+      - Wed, 08 Jul 2026 18:43:29 GMT
       Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -724,9 +723,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "950"
       X-Request-Id:
-      - 603f27c6-1d27-4ccf-8bfc-84ed6119c075
+      - a75aff17-9639-4eca-86c3-9d1a6d262afb
     status: 200 OK
     code: 200
     duration: ""
@@ -738,18 +737,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -762,9 +761,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:29 GMT
       Etag:
-      - W/"5045412370a20173429ac3ddb0a67421"
+      - W/"355d82723306e0442b5823e94ff7512f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -772,9 +771,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "949"
       X-Request-Id:
-      - 1e1a63f1-0594-4289-8c90-d6a3a1be94ea
+      - a580833e-c6c0-446d-a64a-0b48ddc29035
     status: 200 OK
     code: 200
     duration: ""
@@ -786,12 +785,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_pB9DjnTpH9xlHDZL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_nd0lMdcBDX7CqrtG
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -806,9 +805,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:30 GMT
       Etag:
-      - W/"ae51ec91cde8e32b4b0a6a5380da995a"
+      - W/"13d4c38784fef9b2d66d3f6947ae306d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -816,9 +815,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "948"
       X-Request-Id:
-      - 24666b6c-e6b6-419b-bce8-7a7a395b62ca
+      - f654d17d-cf69-443f-bcf6-7dd60a62098d
     status: 200 OK
     code: 200
     duration: ""
@@ -830,18 +829,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -854,181 +853,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:30 GMT
       Etag:
-      - W/"5045412370a20173429ac3ddb0a67421"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "954"
-      X-Request-Id:
-      - fb82a5e3-14b2-423c-b8a5-747a1e4b7a36
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q23NnxOlykfd6fBZ","name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.115/22"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "525"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
-      Etag:
-      - W/"22d2eb7b781e046556be69197abb6cc8"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "953"
-      X-Request-Id:
-      - 6eb0bbe0-378b-42f2-af09-ea47b540891a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "527"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
-      Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - 40283c43-8e3e-436f-9ab8-860a79f2538b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "527"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
-      Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - 2f9cb9d5-47b7-4ba1-9aec-2a6bd108cf1d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_pB9DjnTpH9xlHDZL
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "892"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
-      Etag:
-      - W/"ae51ec91cde8e32b4b0a6a5380da995a"
+      - W/"355d82723306e0442b5823e94ff7512f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1038,55 +865,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "947"
       X-Request-Id:
-      - 52443c30-ccb9-4708-95b2-be2b124853f6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
-      Etag:
-      - W/"5045412370a20173429ac3ddb0a67421"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "944"
-      X-Request-Id:
-      - 77174086-2208-4cd1-9ea1-d70cb5d94ddb
+      - dc8e7174-a053-47d7-a7e6-e52b8fe52ec3
     status: 200 OK
     code: 200
     duration: ""
@@ -1096,12 +875,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q23NnxOlykfd6fBZ","name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.115/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wDt6ozD2seLndKdr","name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.221/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1116,9 +895,139 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:30 GMT
       Etag:
-      - W/"22d2eb7b781e046556be69197abb6cc8"
+      - W/"9d891744d5badb1d535db510a7f9616c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 5c91e88c-021c-4ab6-84d7-0b473aae1bc3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "527"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:30 GMT
+      Etag:
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 00aae6eb-b6e3-47b8-8aa5-3466956b5616
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "527"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:30 GMT
+      Etag:
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - 22011af5-e538-4230-80f9-2766a540e324
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_nd0lMdcBDX7CqrtG
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "892"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:30 GMT
+      Etag:
+      - W/"13d4c38784fef9b2d66d3f6947ae306d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1128,7 +1037,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "943"
       X-Request-Id:
-      - b7fb4dcd-f710-4470-879a-dc6086eacfdd
+      - 0cee2abc-fd52-4ec0-b365-23b38dc6e794
     status: 200 OK
     code: 200
     duration: ""
@@ -1136,14 +1045,22 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1153,14 +1070,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "527"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:30 GMT
       Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
+      - W/"355d82723306e0442b5823e94ff7512f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1170,7 +1085,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "942"
       X-Request-Id:
-      - 717d5d61-4006-4130-9b5d-9b90572271f9
+      - b82f0c76-3786-4028-8081-1f5b92fe2780
     status: 200 OK
     code: 200
     duration: ""
@@ -1178,16 +1093,56 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wDt6ozD2seLndKdr","name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.221/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "525"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:30 GMT
+      Etag:
+      - W/"9d891744d5badb1d535db510a7f9616c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "941"
+      X-Request-Id:
+      - d8568349-00f1-4d1c-a4fe-10275e03564c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1202,9 +1157,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:30 GMT
       Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1214,7 +1169,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "940"
       X-Request-Id:
-      - 1f7ff5e6-0898-405c-8643-e4977f2d4552
+      - 854f91ce-0a0f-437f-a4ed-c878701fe6d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1226,18 +1181,62 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "527"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:30 GMT
+      Etag:
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "939"
+      X-Request-Id:
+      - d16c78f5-a128-46be-beb7-f70c437577a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1250,9 +1249,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:30 GMT
       Etag:
-      - W/"5045412370a20173429ac3ddb0a67421"
+      - W/"355d82723306e0442b5823e94ff7512f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1260,9 +1259,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "937"
+      - "938"
       X-Request-Id:
-      - c56010ab-0622-4f39-b4dd-2eaae1e47e6b
+      - df53eb13-3045-4f3b-90e7-17191d4a4f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1293,7 +1292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:30 GMT
       Etag:
       - W/"1a22b1e94ba820ef313e1dd914e6c766"
       Strict-Transport-Security:
@@ -1303,15 +1302,245 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
+      - "937"
+      X-Request-Id:
+      - 97724c48-e683-4690-b16d-bd3bac711857
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:30 GMT
+      Etag:
+      - W/"355d82723306e0442b5823e94ff7512f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "936"
+      X-Request-Id:
+      - a50d4c16-e3d9-4bac-8b7f-30e30a957c3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_packages/_?virtual_machine_package%5Bpermalink%5D=rock-3
+    method: GET
+  response:
+    body: '{"virtual_machine_package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "329"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:30 GMT
+      Etag:
+      - W/"1a22b1e94ba820ef313e1dd914e6c766"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "935"
+      X-Request-Id:
+      - 67ef306c-b1df-4f19-9b51-fa580dfb85ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:31 GMT
+      Etag:
+      - W/"355d82723306e0442b5823e94ff7512f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
       - "934"
       X-Request-Id:
-      - 2e485ae5-d278-4a4c-af95-994ef60a7e02
+      - 48170909-5957-4245-9e1b-7b01a7221b8a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_packages/_?virtual_machine_package%5Bpermalink%5D=rock-3
+    method: GET
+  response:
+    body: '{"virtual_machine_package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "329"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:31 GMT
+      Etag:
+      - W/"1a22b1e94ba820ef313e1dd914e6c766"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "933"
+      X-Request-Id:
+      - a3e53346-cc57-4a9e-b3b8-626e14d93f98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:31 GMT
+      Etag:
+      - W/"355d82723306e0442b5823e94ff7512f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "932"
+      X-Request-Id:
+      - a057a136-5099-43b3-8f34-068afa567719
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu"},"virtual_machine_package":{"permalink":"rock-3"}}
+      {"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4"},"virtual_machine_package":{"permalink":"rock-3"}}
     form: {}
     headers:
       Accept:
@@ -1323,7 +1552,7 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_/package
     method: PUT
   response:
-    body: '{"task":{"id":"task_XhQDWV7SAANtGIxy","name":"Change package","status":"pending","created_at":1780867173,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_ueH6NT01zaOHwxyf","name":"Change package","status":"pending","created_at":1783536211,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1338,9 +1567,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:35 GMT
+      - Wed, 08 Jul 2026 18:43:31 GMT
       Etag:
-      - W/"01a36d21a0158be7c5c0dffeb91cc10d"
+      - W/"3e666dcc72a7a102366ee2a4e8cb8f15"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1348,9 +1577,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "933"
+      - "931"
       X-Request-Id:
-      - 39042a01-bd93-4fdb-b875-3deb54e253d7
+      - 685e84c6-200c-4057-a5bf-5ca490a0281e
     status: 200 OK
     code: 200
     duration: ""
@@ -1362,10 +1591,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_XhQDWV7SAANtGIxy
+    url: https://api.katapult.io/core/v1/tasks/task_ueH6NT01zaOHwxyf
     method: GET
   response:
-    body: '{"task":{"id":"task_XhQDWV7SAANtGIxy","name":"Change package","status":"pending","created_at":1780867173,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_ueH6NT01zaOHwxyf","name":"Change package","status":"pending","created_at":1783536211,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1380,9 +1609,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:36 GMT
+      - Wed, 08 Jul 2026 18:43:32 GMT
       Etag:
-      - W/"01a36d21a0158be7c5c0dffeb91cc10d"
+      - W/"3e666dcc72a7a102366ee2a4e8cb8f15"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1390,9 +1619,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "927"
+      - "930"
       X-Request-Id:
-      - 27584712-df7c-4d70-8ced-2ec5b71f0fd4
+      - 74ce9368-8a37-4ccb-813c-1b82dc37f404
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,10 +1633,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_XhQDWV7SAANtGIxy
+    url: https://api.katapult.io/core/v1/tasks/task_ueH6NT01zaOHwxyf
     method: GET
   response:
-    body: '{"task":{"id":"task_XhQDWV7SAANtGIxy","name":"Change package","status":"running","created_at":1780867173,"started_at":1780867179,"finished_at":null,"progress":25}}'
+    body: '{"task":{"id":"task_ueH6NT01zaOHwxyf","name":"Change package","status":"pending","created_at":1783536211,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1418,13 +1647,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "163"
+      - "156"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:41 GMT
+      - Wed, 08 Jul 2026 18:43:37 GMT
       Etag:
-      - W/"c1d9ae6ed4903bf97516b0dd477f61f1"
+      - W/"3e666dcc72a7a102366ee2a4e8cb8f15"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1432,9 +1661,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "926"
+      - "928"
       X-Request-Id:
-      - 4f68a3fe-3f82-4d04-b6be-f48dfdccc4b9
+      - 512a4fed-3cf1-4ca7-a495-fabb0a330ff4
     status: 200 OK
     code: 200
     duration: ""
@@ -1446,10 +1675,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_XhQDWV7SAANtGIxy
+    url: https://api.katapult.io/core/v1/tasks/task_ueH6NT01zaOHwxyf
     method: GET
   response:
-    body: '{"task":{"id":"task_XhQDWV7SAANtGIxy","name":"Change package","status":"completed","created_at":1780867173,"started_at":1780867179,"finished_at":1780867183,"progress":100}}'
+    body: '{"task":{"id":"task_ueH6NT01zaOHwxyf","name":"Change package","status":"completed","created_at":1783536211,"started_at":1783536220,"finished_at":1783536223,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1464,9 +1693,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:47 GMT
       Etag:
-      - W/"5760fa8e6c268519125561cd8d5c309e"
+      - W/"1ab0fc9209155d7cb194976229a0d5f6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1474,15 +1703,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "906"
+      - "903"
       X-Request-Id:
-      - ef423412-1dcc-4041-a2f0-9004832e3a47
+      - c60c8650-e719-4544-9960-d963bce28a3c
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu"},"properties":{}}
+      {"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4"},"properties":{}}
     form: {}
     headers:
       Accept:
@@ -1494,15 +1723,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1515,9 +1744,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:47 GMT
       Etag:
-      - W/"962b6e03672dfcb88b45bb2f5bef5dbd"
+      - W/"ffb2ebe1c6854b674a12fdc5ec3c9d16"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1525,9 +1754,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "903"
+      - "902"
       X-Request-Id:
-      - 2bcf2bfc-acb4-4f61-8545-ac35ceddb571
+      - 7e6f3350-b821-4843-a34b-1c8fb2a4cd9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1539,18 +1768,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1563,9 +1792,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:47 GMT
       Etag:
-      - W/"962b6e03672dfcb88b45bb2f5bef5dbd"
+      - W/"ffb2ebe1c6854b674a12fdc5ec3c9d16"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1573,9 +1802,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "902"
+      - "901"
       X-Request-Id:
-      - d04f2559-b3a5-449b-b971-cffc98f1e3a6
+      - ab4a3a2d-4451-4877-9876-e067b208b65a
     status: 200 OK
     code: 200
     duration: ""
@@ -1585,12 +1814,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q23NnxOlykfd6fBZ","name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.115/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wDt6ozD2seLndKdr","name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.221/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1605,9 +1834,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:47 GMT
       Etag:
-      - W/"22d2eb7b781e046556be69197abb6cc8"
+      - W/"9d891744d5badb1d535db510a7f9616c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1615,9 +1844,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "901"
+      - "900"
       X-Request-Id:
-      - 6dcb91f8-5bed-4eb9-8751-49d8c1a6381b
+      - 7ad357cf-ec2f-4998-a07e-d7a640c1cab9
     status: 200 OK
     code: 200
     duration: ""
@@ -1627,12 +1856,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1647,9 +1876,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:47 GMT
       Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1657,9 +1886,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "900"
+      - "899"
       X-Request-Id:
-      - 61ea5245-cba6-4ffb-838b-133522ffbf29
+      - 2e84e4a1-fbf1-4627-96b3-68cdcbd4b7de
     status: 200 OK
     code: 200
     duration: ""
@@ -1671,12 +1900,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1691,9 +1920,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:47 GMT
       Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1701,9 +1930,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "899"
+      - "898"
       X-Request-Id:
-      - 4f491baa-269e-4fd3-8d45-35d831b8aa31
+      - 17c281e2-1bc1-4c2f-9f8c-13dc681a1f9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1715,18 +1944,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1739,9 +1968,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:48 GMT
       Etag:
-      - W/"962b6e03672dfcb88b45bb2f5bef5dbd"
+      - W/"ffb2ebe1c6854b674a12fdc5ec3c9d16"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1749,9 +1978,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "898"
+      - "897"
       X-Request-Id:
-      - 87ba1c37-1a00-440f-8163-c44565c401f9
+      - cacb376d-b2df-47ab-a86f-7e525b654386
     status: 200 OK
     code: 200
     duration: ""
@@ -1763,12 +1992,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_pB9DjnTpH9xlHDZL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_nd0lMdcBDX7CqrtG
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1783,9 +2012,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:48 GMT
       Etag:
-      - W/"ae51ec91cde8e32b4b0a6a5380da995a"
+      - W/"13d4c38784fef9b2d66d3f6947ae306d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1793,9 +2022,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "897"
+      - "896"
       X-Request-Id:
-      - 236d8d9f-8bd2-408f-959f-76cd3cd9b737
+      - 26a36a60-9187-43b5-a555-0b6e4d6f9bc3
     status: 200 OK
     code: 200
     duration: ""
@@ -1807,18 +2036,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1831,9 +2060,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:48 GMT
       Etag:
-      - W/"962b6e03672dfcb88b45bb2f5bef5dbd"
+      - W/"ffb2ebe1c6854b674a12fdc5ec3c9d16"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1843,7 +2072,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "895"
       X-Request-Id:
-      - edc12fc3-639c-40fa-a7fb-2a6120448cd7
+      - 527a369e-f503-4ccb-8f5c-33ff5ce83a75
     status: 200 OK
     code: 200
     duration: ""
@@ -1853,12 +2082,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q23NnxOlykfd6fBZ","name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.115/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wDt6ozD2seLndKdr","name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.221/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1873,9 +2102,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:48 GMT
       Etag:
-      - W/"22d2eb7b781e046556be69197abb6cc8"
+      - W/"9d891744d5badb1d535db510a7f9616c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1885,7 +2114,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "894"
       X-Request-Id:
-      - 1a4db14e-3df5-4573-be9d-131022422f80
+      - c34ddf27-e496-47c2-a191-4c30bf8e9c69
     status: 200 OK
     code: 200
     duration: ""
@@ -1895,12 +2124,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1915,9 +2144,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:48 GMT
       Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1927,7 +2156,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "893"
       X-Request-Id:
-      - 4f6419b0-39af-4eab-bb57-d6ae1bbd274d
+      - 64b274fc-6da0-4d95-accb-86b3a338deb0
     status: 200 OK
     code: 200
     duration: ""
@@ -1939,12 +2168,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q23NnxOlykfd6fBZ
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wDt6ozD2seLndKdr
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q23NnxOlykfd6fBZ","virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q"},"name":"Public
-      Network on tf-acc-test-update-package-dhc8vwfhs97q","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:c2:f4:c6:f8:cb","state":"attached","ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wDt6ozD2seLndKdr","virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7"},"name":"Public
+      Network on tf-acc-test-update-package-rfdcmntu1cz7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cf:44:9d:79:6d","state":"attached","ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1959,9 +2188,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:43:48 GMT
       Etag:
-      - W/"69843d2a9e6580529d1f774fcc73ad18"
+      - W/"9d2f786d7a93f6f0dd6d7573696344bf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1971,7 +2200,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "892"
       X-Request-Id:
-      - d9414fde-fd90-4b72-bcc9-ce56e15075ac
+      - 29406107-278c-45b8-ad26-1db6b284523c
     status: 200 OK
     code: 200
     duration: ""
@@ -1983,18 +2212,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2007,9 +2236,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:52 GMT
+      - Wed, 08 Jul 2026 18:43:48 GMT
       Etag:
-      - W/"962b6e03672dfcb88b45bb2f5bef5dbd"
+      - W/"ffb2ebe1c6854b674a12fdc5ec3c9d16"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2019,7 +2248,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "891"
       X-Request-Id:
-      - 95cd6af3-f562-4563-8960-8b512dab8669
+      - 8b47b502-1415-45d7-9b67-6df2209f88c2
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,10 +2260,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: POST
   response:
-    body: '{"task":{"id":"task_TylsJiNpqcjFT3Wj","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_rcZVpjKzez3LyHCf","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2049,9 +2278,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:52 GMT
+      - Wed, 08 Jul 2026 18:43:48 GMT
       Etag:
-      - W/"3a0462145fd410dc2c03bb59708e295d"
+      - W/"624040588d274bd2e3a4eaff288f0c9e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2061,7 +2290,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "890"
       X-Request-Id:
-      - 9d61b966-96ef-453e-a354-b0c785835fd8
+      - 03b5aa81-7c73-403e-96c9-8e0600c25c25
     status: 200 OK
     code: 200
     duration: ""
@@ -2073,10 +2302,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_TylsJiNpqcjFT3Wj
+    url: https://api.katapult.io/core/v1/tasks/task_rcZVpjKzez3LyHCf
     method: GET
   response:
-    body: '{"task":{"id":"task_TylsJiNpqcjFT3Wj","name":"Stop virtual machine","status":"running","created_at":1780867192,"started_at":1780867192,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_rcZVpjKzez3LyHCf","name":"Stop virtual machine","status":"pending","created_at":1783536228,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2087,13 +2316,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "162"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:53 GMT
+      - Wed, 08 Jul 2026 18:43:49 GMT
       Etag:
-      - W/"229b2db0078525dfe2de4e4d2dc8d4c1"
+      - W/"8f607fefdc7da4602fac59cd85c14863"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2101,9 +2330,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "885"
+      - "889"
       X-Request-Id:
-      - 4704b3ac-b6e3-4d7e-b43c-811d26fc6c0c
+      - 74dabf31-dcc4-425e-af77-6d6ba5b51084
     status: 200 OK
     code: 200
     duration: ""
@@ -2115,10 +2344,52 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_TylsJiNpqcjFT3Wj
+    url: https://api.katapult.io/core/v1/tasks/task_rcZVpjKzez3LyHCf
     method: GET
   response:
-    body: '{"task":{"id":"task_TylsJiNpqcjFT3Wj","name":"Stop virtual machine","status":"completed","created_at":1780867192,"started_at":1780867192,"finished_at":1780867194,"progress":100}}'
+    body: '{"task":{"id":"task_rcZVpjKzez3LyHCf","name":"Stop virtual machine","status":"running","created_at":1783536228,"started_at":1783536232,"finished_at":null,"progress":29}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "169"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:54 GMT
+      Etag:
+      - W/"b6de6ccbb64d9bdbba772868224438b1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "873"
+      X-Request-Id:
+      - 577c09d0-2d4f-41db-952f-9f62fabf7784
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_rcZVpjKzez3LyHCf
+    method: GET
+  response:
+    body: '{"task":{"id":"task_rcZVpjKzez3LyHCf","name":"Stop virtual machine","status":"completed","created_at":1783536228,"started_at":1783536232,"finished_at":1783536236,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2133,9 +2404,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:58 GMT
+      - Wed, 08 Jul 2026 18:44:04 GMT
       Etag:
-      - W/"12a5171ab607ae9537c90df779f1d779"
+      - W/"6005eeef7a3ca8850e8990aa8c90552a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2143,9 +2414,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "877"
+      - "994"
       X-Request-Id:
-      - 83c59c71-572a-425f-a6e9-3e8ab2eefb45
+      - 7712dc14-5f2c-48d5-ae4a-cc359b02d2f9
     status: 200 OK
     code: 200
     duration: ""
@@ -2157,18 +2428,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2181,9 +2452,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:59 GMT
+      - Wed, 08 Jul 2026 18:44:06 GMT
       Etag:
-      - W/"7a7eb2ecceeca088e694ab015794f8c7"
+      - W/"ef317e53878580db6003806d98ae2e10"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2191,9 +2462,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "876"
+      - "993"
       X-Request-Id:
-      - 4363d9a9-db93-4109-8582-bd1b2d904ecd
+      - 5311f633-a5ab-44c9-bbd3-64b9e832bdbb
     status: 200 OK
     code: 200
     duration: ""
@@ -2205,18 +2476,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_pTaRUAQJUpOd1YQE","keep_until":1781039999,"object_id":"vm_wJhKZ8L0aH9oA1Iu","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_wJhKZ8L0aH9oA1Iu","name":"tf-acc-test-update-package-dhc8vwfhs97q","hostname":"tf-acc-test-update-package-dhc8vwfhs97q-host","fqdn":"tf-acc-test-update-package-dhc8vwfhs97q-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867133,"initial_root_password":"TG9TZViSXYarTkUr","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_MI2iAkuCo1hwgpRN","keep_until":1783709046,"object_id":"vm_kc3dHMcjfyMZExj4","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_kc3dHMcjfyMZExj4","name":"tf-acc-test-update-package-rfdcmntu1cz7","hostname":"tf-acc-test-update-package-rfdcmntu1cz7-host","fqdn":"tf-acc-test-update-package-rfdcmntu1cz7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536175,"initial_root_password":"B2ohlKIeQz38gE7H","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_pB9DjnTpH9xlHDZL","address":"185.44.254.115","reverse_dns":"185-44-254-115.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.115/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_nd0lMdcBDX7CqrtG","address":"185.44.254.221","reverse_dns":"185-44-254-221.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.221/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_wJhKZ8L0aH9oA1Iu","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_kc3dHMcjfyMZExj4","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2229,9 +2500,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:59 GMT
+      - Wed, 08 Jul 2026 18:44:06 GMT
       Etag:
-      - W/"347eaf690b61b8497800faa5c8c17d62"
+      - W/"9feb3ab346d329802a2340707a0a2b39"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2239,9 +2510,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "875"
+      - "991"
       X-Request-Id:
-      - 952fd5ac-7d71-4091-a259-b38dc53387bc
+      - 2da864e9-7256-4010-a016-2f763d9f1cf4
     status: 200 OK
     code: 200
     duration: ""
@@ -2253,7 +2524,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_pB9DjnTpH9xlHDZL
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_nd0lMdcBDX7CqrtG
     method: POST
   response:
     body: '{}'
@@ -2271,7 +2542,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:00 GMT
+      - Wed, 08 Jul 2026 18:44:07 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2281,9 +2552,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "873"
+      - "990"
       X-Request-Id:
-      - 9628d0d2-50f2-4f3b-856d-8b67b4088976
+      - 9ad61872-99f1-4e43-bfad-b65acf6b9b0f
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2566,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kc3dHMcjfyMZExj4
     method: DELETE
   response:
-    body: '{"task":{"id":"task_iWXXus945iji1hXZ","name":"Purge items from trash","status":"pending","created_at":1780867200,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_rZtv85mMrNu4NVrM","name":"Purge items from trash","status":"pending","created_at":1783536247,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2313,9 +2584,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:00 GMT
+      - Wed, 08 Jul 2026 18:44:07 GMT
       Etag:
-      - W/"41087ee807aa537c8fed7af8fb5265ff"
+      - W/"dad1a94fbe75bfd565f124cfd3d3195c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2323,9 +2594,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "989"
       X-Request-Id:
-      - 1ebdd5d1-26ee-4017-8997-e8aa4df68490
+      - bb65b113-edf4-49eb-b891-3594f9d1a335
     status: 200 OK
     code: 200
     duration: ""
@@ -2337,10 +2608,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_pTaRUAQJUpOd1YQE","keep_until":1781039999,"object_id":"vm_wJhKZ8L0aH9oA1Iu","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_MI2iAkuCo1hwgpRN","keep_until":1783709046,"object_id":"vm_kc3dHMcjfyMZExj4","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2355,9 +2626,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:01 GMT
+      - Wed, 08 Jul 2026 18:44:08 GMT
       Etag:
-      - W/"5fe438254139724b33c93029ed968398"
+      - W/"2367aa096d825012c7efe3e2481cd7c6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2365,9 +2636,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "988"
       X-Request-Id:
-      - 37f79bbd-cf6c-4fb3-a161-247e3c6da505
+      - 64637ae7-8726-4a3d-9a0e-fe9446e75c2a
     status: 200 OK
     code: 200
     duration: ""
@@ -2379,10 +2650,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_pTaRUAQJUpOd1YQE","keep_until":1781039999,"object_id":"vm_wJhKZ8L0aH9oA1Iu","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_MI2iAkuCo1hwgpRN","keep_until":1783709046,"object_id":"vm_kc3dHMcjfyMZExj4","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2397,9 +2668,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:06 GMT
+      - Wed, 08 Jul 2026 18:44:13 GMT
       Etag:
-      - W/"5fe438254139724b33c93029ed968398"
+      - W/"2367aa096d825012c7efe3e2481cd7c6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2407,9 +2678,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "976"
       X-Request-Id:
-      - 4ca066bf-dd9b-4624-b0ea-9392e9edc244
+      - 1c12fdba-0bbf-46ed-92a6-cba5d4bb68e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2421,10 +2692,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_pTaRUAQJUpOd1YQE","keep_until":1781039999,"object_id":"vm_wJhKZ8L0aH9oA1Iu","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_MI2iAkuCo1hwgpRN","keep_until":1783709046,"object_id":"vm_kc3dHMcjfyMZExj4","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2439,9 +2710,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:16 GMT
+      - Wed, 08 Jul 2026 18:44:23 GMT
       Etag:
-      - W/"5fe438254139724b33c93029ed968398"
+      - W/"2367aa096d825012c7efe3e2481cd7c6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2449,9 +2720,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "974"
       X-Request-Id:
-      - da572079-a3b9-4af6-8265-3fd5d78cbc0d
+      - 0cecfd60-6597-4cf6-84f4-4b9e87021ec6
     status: 200 OK
     code: 200
     duration: ""
@@ -2463,49 +2734,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_wJhKZ8L0aH9oA1Iu
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_pTaRUAQJUpOd1YQE","keep_until":1781039999,"object_id":"vm_wJhKZ8L0aH9oA1Iu","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:20:26 GMT
-      Etag:
-      - W/"5fe438254139724b33c93029ed968398"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - 41d1444e-353f-4fa3-808a-e207f8374b38
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2524,7 +2753,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:36 GMT
+      - Wed, 08 Jul 2026 18:44:33 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2534,9 +2763,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "972"
       X-Request-Id:
-      - dbcbf13f-2f7d-4fa0-8fcf-0ffdd6034314
+      - 89e98537-d990-4f29-af3f-ad30df16e2cd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2548,7 +2777,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_pB9DjnTpH9xlHDZL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_nd0lMdcBDX7CqrtG
     method: DELETE
   response:
     body: '{}'
@@ -2566,7 +2795,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:36 GMT
+      - Wed, 08 Jul 2026 18:44:33 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2576,9 +2805,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "971"
       X-Request-Id:
-      - 4b749fce-054e-406d-b119-80f20ce2d6f2
+      - bfc2d10a-d61d-41e9-9988-1c612665a5a2
     status: 200 OK
     code: 200
     duration: ""
@@ -2590,7 +2819,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2609,7 +2838,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:36 GMT
+      - Wed, 08 Jul 2026 18:44:33 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2619,9 +2848,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "970"
       X-Request-Id:
-      - 1fb03740-57d0-44d2-864d-70576042e473
+      - 2868b729-bb38-44ce-a3b4-d7b5a86beca9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2633,7 +2862,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_wJhKZ8L0aH9oA1Iu
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kc3dHMcjfyMZExj4
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2652,7 +2881,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:36 GMT
+      - Wed, 08 Jul 2026 18:44:33 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2662,9 +2891,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "969"
       X-Request-Id:
-      - ccdb8652-50d5-4dd3-a9c6-0ddc24df6469
+      - 44b9eba9-dadf-486e-80eb-fb375f1cc04e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2676,7 +2905,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_pB9DjnTpH9xlHDZL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_nd0lMdcBDX7CqrtG
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2695,7 +2924,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:36 GMT
+      - Wed, 08 Jul 2026 18:44:33 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2705,9 +2934,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "968"
       X-Request-Id:
-      - bfa22e9d-1f7f-43e7-9870-dbd5a66d2a16
+      - f5eda4bb-3096-4630-a594-d1f1a7b0c8c6
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_package_by_id.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_package_by_id.cassette.rand_id
@@ -1,1 +1,1 @@
-0kzocmfzomxx
+8xzo1gqx9iil

--- a/internal/provider/testdata/VirtualMachine_update_package_by_id.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_package_by_id.cassette.yaml
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "999"
       X-Request-Id:
-      - 1dcb33e6-e9b6-4a26-a03b-d4a42fe0c789
+      - 7997ea4f-260b-42af-806e-d0d81311e073
     status: 200 OK
     code: 200
     duration: ""
@@ -57,7 +57,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"185-44-255-130.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"185-44-252-174.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -74,9 +74,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"7b8a015606e965e14c6400d26ce952e3"
+      - W/"8670267eabf53151140cf8eb767117f8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -84,9 +84,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "996"
       X-Request-Id:
-      - 77eab3c0-fd37-45fd-84c6-08bf1b119166
+      - b7575c8d-82b3-4b66-98a0-5ab40e968f2e
     status: 200 OK
     code: 200
     duration: ""
@@ -98,10 +98,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_u7ChXWznxpZm01zF
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JOJhTFtsqly6fUBI
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"185-44-255-130.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"185-44-252-174.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -118,9 +118,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"59c7a08af2742806d600bf122ca5bbfd"
+      - W/"6e4f94b94e5b6d439d1e1fe624e353d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -128,9 +128,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "993"
       X-Request-Id:
-      - 793ebff1-eefa-4212-80ae-14ed0247ef61
+      - 090b71b2-54a0-4279-b5ec-eba81e1c4524
     status: 200 OK
     code: 200
     duration: ""
@@ -142,10 +142,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_u7ChXWznxpZm01zF
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JOJhTFtsqly6fUBI
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"185-44-255-130.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"185-44-252-174.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -162,9 +162,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"59c7a08af2742806d600bf122ca5bbfd"
+      - W/"6e4f94b94e5b6d439d1e1fe624e353d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -172,15 +172,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "992"
       X-Request-Id:
-      - 6b203df1-7305-4800-a2d0-a919b13a64d1
+      - a2f189ce-795f-4919-90c1-5ade1165f161
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package>vmpkg_dhG25G5SX3HrA5j5</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_u7ChXWznxpZm01zF</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-package-by-id-0kzocmfzomxx-host</Hostname></Hostname><Name>tf-acc-test-update-package-by-id-0kzocmfzomxx</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package>vmpkg_dhG25G5SX3HrA5j5</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_JOJhTFtsqly6fUBI</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-package-by-id-8xzo1gqx9iil-host</Hostname></Hostname><Name>tf-acc-test-update-package-by-id-8xzo1gqx9iil</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -192,7 +192,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_imWTSpA55zNDCBUX","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_ZPKAc7qVSXzxl6eu","state":"pending"},"virtual_machine_build":{"id":"vmbuild_ZPKAc7qVSXzxl6eu","state":"pending"},"hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","annotations":[]}'
+    body: '{"task":{"id":"task_YtQ0n5o525121THO","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_3AR7JhVE228PDOoW","state":"pending"},"virtual_machine_build":{"id":"vmbuild_3AR7JhVE228PDOoW","state":"pending"},"hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -207,9 +207,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:48 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"be6925095162b02787b5dbd1fe2c933c"
+      - W/"ef9c143f068e9aa63d996763544f4c2c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -217,9 +217,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "991"
       X-Request-Id:
-      - c61f4ec8-9fcf-44cd-b6e6-71992e7914c7
+      - 792ac98a-ce66-41b6-b080-9f9c5f010c1b
     status: 201 Created
     code: 201
     duration: ""
@@ -231,17 +231,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ZPKAc7qVSXzxl6eu
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_3AR7JhVE228PDOoW
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ZPKAc7qVSXzxl6eu","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_3AR7JhVE228PDOoW","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.130\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-by-id-0kzocmfzomxx-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-by-id-0kzocmfzomxx\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.174\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-by-id-8xzo1gqx9iil-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-by-id-8xzo1gqx9iil\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1780867128},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -254,9 +254,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:50 GMT
+      - Wed, 08 Jul 2026 18:42:41 GMT
       Etag:
-      - W/"34a33ead83df8b528c580770a442b9bc"
+      - W/"4bada9733bc0007a596f4572f9c0b17b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -264,9 +264,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "984"
       X-Request-Id:
-      - 05566167-abd9-4633-8b84-a937e56fcb09
+      - 68507f6d-da95-4f2c-afba-2d46e228796e
     status: 200 OK
     code: 200
     duration: ""
@@ -278,17 +278,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ZPKAc7qVSXzxl6eu
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_3AR7JhVE228PDOoW
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ZPKAc7qVSXzxl6eu","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_3AR7JhVE228PDOoW","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.130\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-by-id-0kzocmfzomxx-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-by-id-0kzocmfzomxx\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.174\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-by-id-8xzo1gqx9iil-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-by-id-8xzo1gqx9iil\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1780867128},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -301,9 +301,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:55 GMT
+      - Wed, 08 Jul 2026 18:42:46 GMT
       Etag:
-      - W/"4bd25a5d0bd00aff251323c57cd147c6"
+      - W/"4bada9733bc0007a596f4572f9c0b17b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -311,9 +311,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "980"
+      - "981"
       X-Request-Id:
-      - 2d907650-7f77-4755-923b-4ef255530320
+      - 772869e6-3962-473e-af79-d977e180bad6
     status: 200 OK
     code: 200
     duration: ""
@@ -325,17 +325,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ZPKAc7qVSXzxl6eu
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_3AR7JhVE228PDOoW
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ZPKAc7qVSXzxl6eu","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_3AR7JhVE228PDOoW","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.130\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-by-id-0kzocmfzomxx-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-by-id-0kzocmfzomxx\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.174\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-by-id-8xzo1gqx9iil-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-by-id-8xzo1gqx9iil\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1780867128},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -348,9 +348,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:05 GMT
+      - Wed, 08 Jul 2026 18:42:56 GMT
       Etag:
-      - W/"4bd25a5d0bd00aff251323c57cd147c6"
+      - W/"14b9c46d28893743dc0a8edd9dd40e67"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -358,9 +358,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "971"
       X-Request-Id:
-      - c8db12a3-0211-4a8b-a474-8c4482fa05f1
+      - 7f67b3e4-36f8-47f0-a83d-215b00a8a898
     status: 200 OK
     code: 200
     duration: ""
@@ -372,17 +372,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ZPKAc7qVSXzxl6eu
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_3AR7JhVE228PDOoW
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ZPKAc7qVSXzxl6eu","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_3AR7JhVE228PDOoW","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.130\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-by-id-0kzocmfzomxx-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-by-id-0kzocmfzomxx\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.174\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-by-id-8xzo1gqx9iil-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-by-id-8xzo1gqx9iil\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1780867128},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -395,9 +395,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:15 GMT
+      - Wed, 08 Jul 2026 18:43:06 GMT
       Etag:
-      - W/"8a0eec16d6499658870e402d527214df"
+      - W/"160074f05c22065ed0a38015d1f42511"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -405,9 +405,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "999"
       X-Request-Id:
-      - 0880259a-df03-4703-b86f-18c5b652d89d
+      - 1e6c1970-6232-4d93-851f-0eabfe4f1482
     status: 200 OK
     code: 200
     duration: ""
@@ -419,18 +419,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"starting","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -443,9 +443,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:17 GMT
+      - Wed, 08 Jul 2026 18:43:09 GMT
       Etag:
-      - W/"80b0df073bdbd97ee9915c448b8e6e79"
+      - W/"74b83430557c64510bf194cf200f4b4c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -453,9 +453,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "996"
       X-Request-Id:
-      - 655639ff-f157-4455-975a-f45366deb5e5
+      - 675ad304-7102-4d0f-b27b-c32d694e28c7
     status: 200 OK
     code: 200
     duration: ""
@@ -467,18 +467,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -491,9 +491,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:22 GMT
+      - Wed, 08 Jul 2026 18:43:14 GMT
       Etag:
-      - W/"4c00503da7d5bb1e77b212879d63e1d4"
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -501,9 +501,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "990"
       X-Request-Id:
-      - e4271d20-0dc7-48d6-bf71-04cfea4185ef
+      - cf5ee5a9-57a6-454f-841b-2f855139721b
     status: 200 OK
     code: 200
     duration: ""
@@ -515,18 +515,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -539,9 +539,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:23 GMT
+      - Wed, 08 Jul 2026 18:43:14 GMT
       Etag:
-      - W/"4c00503da7d5bb1e77b212879d63e1d4"
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -549,9 +549,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "989"
       X-Request-Id:
-      - 22e898a7-ef21-4a00-8e6b-3e66e4b923fa
+      - f93aee2b-ae50-478f-8cc4-4976c932428a
     status: 200 OK
     code: 200
     duration: ""
@@ -561,12 +561,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_mJwJ591onNsL67hL","name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.255.130/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_1wmfJWRrQNGTqeDu","name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.174/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -581,9 +581,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:23 GMT
+      - Wed, 08 Jul 2026 18:43:14 GMT
       Etag:
-      - W/"045300df3cb9e1f1fe1c1fa10572c67b"
+      - W/"ddc6c529e125c569a19f216b09427e13"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -591,9 +591,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "988"
       X-Request-Id:
-      - 0a23bbef-9990-4451-b674-6ad40ea0834e
+      - c4e3bae2-ecb3-4a54-82b0-4a2d84ec516b
     status: 200 OK
     code: 200
     duration: ""
@@ -603,12 +603,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -623,9 +623,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:23 GMT
+      - Wed, 08 Jul 2026 18:43:14 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -633,9 +633,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "987"
       X-Request-Id:
-      - ac9f9865-c485-4913-a686-a276cb54bf22
+      - 1d652dd4-19a8-48aa-8c04-db0252e24078
     status: 200 OK
     code: 200
     duration: ""
@@ -647,12 +647,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -667,9 +667,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:24 GMT
+      - Wed, 08 Jul 2026 18:43:14 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -677,9 +677,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "986"
       X-Request-Id:
-      - d13788ec-8b0a-43b0-a2ab-be8d774cb3f3
+      - 951b19ca-06c8-4968-9f69-9bf98566dd77
     status: 200 OK
     code: 200
     duration: ""
@@ -691,18 +691,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -715,9 +715,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:24 GMT
+      - Wed, 08 Jul 2026 18:43:14 GMT
       Etag:
-      - W/"4c00503da7d5bb1e77b212879d63e1d4"
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -725,9 +725,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "985"
       X-Request-Id:
-      - 93e60c06-b8d3-4f99-b49b-6a9c9edf0d38
+      - 230b0621-cddc-45cc-911e-6d7af6a25dee
     status: 200 OK
     code: 200
     duration: ""
@@ -739,12 +739,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_u7ChXWznxpZm01zF
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JOJhTFtsqly6fUBI
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -759,57 +759,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:24 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"459738fedd1020685cedb9eb48b3c044"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - 0d168f91-2bc7-4361-9775-bf280417531d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:25 GMT
-      Etag:
-      - W/"4c00503da7d5bb1e77b212879d63e1d4"
+      - W/"1c3c7befe5208605a8d42832e55aff04"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -819,7 +771,55 @@ interactions:
       X-Ratelimit-Remaining:
       - "984"
       X-Request-Id:
-      - 09833660-2b83-4ad6-bf97-4b77198fc761
+      - 43be51cb-25a4-4b2f-a366-59694172f06a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:15 GMT
+      Etag:
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - d772e690-8aa3-4af7-a3a6-e7d980a0c190
     status: 200 OK
     code: 200
     duration: ""
@@ -829,12 +829,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_mJwJ591onNsL67hL","name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.255.130/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_1wmfJWRrQNGTqeDu","name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.174/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -849,9 +849,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:25 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"045300df3cb9e1f1fe1c1fa10572c67b"
+      - W/"ddc6c529e125c569a19f216b09427e13"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -859,9 +859,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "982"
       X-Request-Id:
-      - 177a8532-8ca8-4441-b378-4af7c0f8480b
+      - eb9c9032-6b74-4e32-a59b-35740ef7beda
     status: 200 OK
     code: 200
     duration: ""
@@ -871,12 +871,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -891,9 +891,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:25 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -903,7 +903,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "981"
       X-Request-Id:
-      - a266d37b-3e5f-4349-942f-47b7ff25e18a
+      - 2b8e4bd5-1072-45b3-b271-cd6fc0e40240
     status: 200 OK
     code: 200
     duration: ""
@@ -915,12 +915,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -935,9 +935,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:25 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -947,7 +947,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "980"
       X-Request-Id:
-      - 19b67cc8-3f49-4014-b9aa-d1d0b578c770
+      - 9d2d413e-861e-42d3-ab3d-e2851c2bcdfb
     status: 200 OK
     code: 200
     duration: ""
@@ -959,12 +959,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_u7ChXWznxpZm01zF
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JOJhTFtsqly6fUBI
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -979,9 +979,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:25 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"459738fedd1020685cedb9eb48b3c044"
+      - W/"1c3c7befe5208605a8d42832e55aff04"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -991,7 +991,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - df026dab-aafb-4cc6-b5fa-84dde4970f1f
+      - c5387e0e-9196-4948-bc05-8f24afef070a
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,18 +1003,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1027,9 +1027,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:26 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"4c00503da7d5bb1e77b212879d63e1d4"
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1039,7 +1039,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "978"
       X-Request-Id:
-      - 4e9ff2e8-d67e-4179-8e91-c30d09c9e407
+      - 9598cc9f-737e-42e6-a3f4-060f008c8b64
     status: 200 OK
     code: 200
     duration: ""
@@ -1049,12 +1049,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_mJwJ591onNsL67hL","name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.255.130/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_1wmfJWRrQNGTqeDu","name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.174/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1069,9 +1069,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:26 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"045300df3cb9e1f1fe1c1fa10572c67b"
+      - W/"ddc6c529e125c569a19f216b09427e13"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1081,7 +1081,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "977"
       X-Request-Id:
-      - f8b48821-bf17-4f75-a8bd-2d8d2df684b7
+      - 3acd390a-b797-429c-8846-2431b21f32c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1091,12 +1091,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1111,9 +1111,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:26 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1123,7 +1123,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - e3c756dd-d5fa-4c8b-b4c3-43ae9d9f5c2f
+      - 662eb99f-0677-4b75-9b31-5dbe9803119a
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,12 +1135,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1155,9 +1155,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:26 GMT
+      - Wed, 08 Jul 2026 18:43:15 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1167,7 +1167,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "975"
       X-Request-Id:
-      - 534854d0-d32f-409f-b47d-821922f4fd26
+      - 38dd48bf-6658-4d3f-a621-aacb16ec0ccf
     status: 200 OK
     code: 200
     duration: ""
@@ -1179,18 +1179,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1203,9 +1203,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:26 GMT
+      - Wed, 08 Jul 2026 18:43:16 GMT
       Etag:
-      - W/"4c00503da7d5bb1e77b212879d63e1d4"
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1215,7 +1215,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "974"
       X-Request-Id:
-      - d0314941-47b0-48c4-89c3-904788251f09
+      - ea513967-f2dc-4366-98cf-4a92a64bedba
     status: 200 OK
     code: 200
     duration: ""
@@ -1246,7 +1246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:26 GMT
+      - Wed, 08 Jul 2026 18:43:16 GMT
       Etag:
       - W/"1a22b1e94ba820ef313e1dd914e6c766"
       Strict-Transport-Security:
@@ -1258,13 +1258,243 @@ interactions:
       X-Ratelimit-Remaining:
       - "973"
       X-Request-Id:
-      - fe06e455-795c-47c4-8f14-70cadfbf1981
+      - 33e10c1f-e4c4-4ee8-99d8-dde4205d7e02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:16 GMT
+      Etag:
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - a691aec7-eeeb-4f8e-9157-71134de6f11d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_packages/_?virtual_machine_package%5Bid%5D=vmpkg_Eh5LYVKScVHpj7sM
+    method: GET
+  response:
+    body: '{"virtual_machine_package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "329"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:16 GMT
+      Etag:
+      - W/"1a22b1e94ba820ef313e1dd914e6c766"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 7e4add0a-15ee-46d2-8ee3-ddca0dca2d70
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:16 GMT
+      Etag:
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - 0bd1d6cc-f6cf-4964-b087-537fe22067c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_packages/_?virtual_machine_package%5Bid%5D=vmpkg_Eh5LYVKScVHpj7sM
+    method: GET
+  response:
+    body: '{"virtual_machine_package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "329"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:16 GMT
+      Etag:
+      - W/"1a22b1e94ba820ef313e1dd914e6c766"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 75a51c70-48ff-4708-847c-69d5a4d2522a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:16 GMT
+      Etag:
+      - W/"70f9f1416e835429c8ffd1e5dc7e75bd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - 8a2db34a-90e4-492f-8004-f3dc01ff334c
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr"},"virtual_machine_package":{"id":"vmpkg_Eh5LYVKScVHpj7sM"}}
+      {"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8"},"virtual_machine_package":{"id":"vmpkg_Eh5LYVKScVHpj7sM"}}
     form: {}
     headers:
       Accept:
@@ -1276,7 +1506,7 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_/package
     method: PUT
   response:
-    body: '{"task":{"id":"task_UINS94OYEj25LLDI","name":"Change package","status":"pending","created_at":1780867166,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_tSN8Iyh2ESOf6C0V","name":"Change package","status":"pending","created_at":1783536196,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1291,9 +1521,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:26 GMT
+      - Wed, 08 Jul 2026 18:43:16 GMT
       Etag:
-      - W/"9a6b9904896dd448ad7fce457053bc73"
+      - W/"22c04c237ce1f424907a93b2a058252a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1301,9 +1531,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "972"
+      - "967"
       X-Request-Id:
-      - b1a2310c-29e2-4c9a-a13b-b7ca58ca269d
+      - cd949b5b-7955-4baa-a237-ba7d2f0c76ad
     status: 200 OK
     code: 200
     duration: ""
@@ -1315,10 +1545,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_UINS94OYEj25LLDI
+    url: https://api.katapult.io/core/v1/tasks/task_tSN8Iyh2ESOf6C0V
     method: GET
   response:
-    body: '{"task":{"id":"task_UINS94OYEj25LLDI","name":"Change package","status":"pending","created_at":1780867166,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_tSN8Iyh2ESOf6C0V","name":"Change package","status":"pending","created_at":1783536196,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1333,9 +1563,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:27 GMT
+      - Wed, 08 Jul 2026 18:43:17 GMT
       Etag:
-      - W/"9a6b9904896dd448ad7fce457053bc73"
+      - W/"22c04c237ce1f424907a93b2a058252a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1343,9 +1573,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "971"
+      - "958"
       X-Request-Id:
-      - 632f0113-4510-4e9c-97d2-9939e702b875
+      - 669167ce-01ae-4fce-b05c-a2c69f73fc70
     status: 200 OK
     code: 200
     duration: ""
@@ -1357,10 +1587,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_UINS94OYEj25LLDI
+    url: https://api.katapult.io/core/v1/tasks/task_tSN8Iyh2ESOf6C0V
     method: GET
   response:
-    body: '{"task":{"id":"task_UINS94OYEj25LLDI","name":"Change package","status":"pending","created_at":1780867166,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_tSN8Iyh2ESOf6C0V","name":"Change package","status":"pending","created_at":1783536196,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1375,9 +1605,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:32 GMT
+      - Wed, 08 Jul 2026 18:43:22 GMT
       Etag:
-      - W/"9a6b9904896dd448ad7fce457053bc73"
+      - W/"22c04c237ce1f424907a93b2a058252a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1385,9 +1615,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "968"
+      - "957"
       X-Request-Id:
-      - 052c3e18-3ab1-437e-959b-ebc25e342257
+      - 65cbc0e6-c419-47c3-90d2-df7a263e5e40
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,10 +1629,94 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_UINS94OYEj25LLDI
+    url: https://api.katapult.io/core/v1/tasks/task_tSN8Iyh2ESOf6C0V
     method: GET
   response:
-    body: '{"task":{"id":"task_UINS94OYEj25LLDI","name":"Change package","status":"completed","created_at":1780867166,"started_at":1780867173,"finished_at":1780867178,"progress":100}}'
+    body: '{"task":{"id":"task_tSN8Iyh2ESOf6C0V","name":"Change package","status":"pending","created_at":1783536196,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "156"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:32 GMT
+      Etag:
+      - W/"22c04c237ce1f424907a93b2a058252a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "929"
+      X-Request-Id:
+      - b3c303a4-35f8-4430-b990-49dad123b79a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_tSN8Iyh2ESOf6C0V
+    method: GET
+  response:
+    body: '{"task":{"id":"task_tSN8Iyh2ESOf6C0V","name":"Change package","status":"running","created_at":1783536196,"started_at":1783536221,"finished_at":null,"progress":25}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "163"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:42 GMT
+      Etag:
+      - W/"13c7f6b9ba9900738dfa3aa46a2d21e5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "925"
+      X-Request-Id:
+      - 591a2168-7cea-4b1b-8947-9fad7c2cd59e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_tSN8Iyh2ESOf6C0V
+    method: GET
+  response:
+    body: '{"task":{"id":"task_tSN8Iyh2ESOf6C0V","name":"Change package","status":"completed","created_at":1783536196,"started_at":1783536221,"finished_at":1783536225,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1417,9 +1731,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:42 GMT
+      - Wed, 08 Jul 2026 18:43:52 GMT
       Etag:
-      - W/"d2e6eec175c3cccf3745b51a585df93f"
+      - W/"610c8e9ef03976c7f6287c5654832982"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1427,15 +1741,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "924"
+      - "887"
       X-Request-Id:
-      - 13792450-0b37-4278-8537-0fa880934d05
+      - d26adecc-0bb7-4e6c-b922-69d302f0767b
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr"},"properties":{}}
+      {"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8"},"properties":{}}
     form: {}
     headers:
       Accept:
@@ -1447,15 +1761,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1468,9 +1782,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:42 GMT
+      - Wed, 08 Jul 2026 18:43:52 GMT
       Etag:
-      - W/"76063bda19e87dae966904680cf5b6ee"
+      - W/"5233e514add985c864a224a9f3b49c6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1478,9 +1792,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "923"
+      - "886"
       X-Request-Id:
-      - 4ed50724-e75f-4df8-9271-b14669962dd6
+      - f3d593ab-5089-46a2-9a0c-2044e4108bcd
     status: 200 OK
     code: 200
     duration: ""
@@ -1492,18 +1806,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1516,9 +1830,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:42 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"76063bda19e87dae966904680cf5b6ee"
+      - W/"5233e514add985c864a224a9f3b49c6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1526,9 +1840,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "922"
+      - "885"
       X-Request-Id:
-      - 2f243ea6-9649-4b50-bab9-91323e33f9ed
+      - 1e7a7ee5-fe74-45cf-bc9e-52374070abd9
     status: 200 OK
     code: 200
     duration: ""
@@ -1538,12 +1852,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_mJwJ591onNsL67hL","name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.255.130/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_1wmfJWRrQNGTqeDu","name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.174/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1558,9 +1872,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:42 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"045300df3cb9e1f1fe1c1fa10572c67b"
+      - W/"ddc6c529e125c569a19f216b09427e13"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1568,9 +1882,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "884"
       X-Request-Id:
-      - bdcda4f8-bf36-4669-a1e9-bf1681fdf1b8
+      - 1a7a1b2e-b3de-4e4f-961c-695f6fddd5a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1580,12 +1894,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1600,9 +1914,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:42 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1610,9 +1924,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "920"
+      - "883"
       X-Request-Id:
-      - 62ff3bcb-95eb-4a0d-9587-124f11d67995
+      - d5ca8e80-9d3a-421c-be5d-7ef48e12ee0d
     status: 200 OK
     code: 200
     duration: ""
@@ -1624,12 +1938,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1644,9 +1958,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:42 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1654,9 +1968,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "919"
+      - "882"
       X-Request-Id:
-      - c3034b90-beb6-4643-b54e-9ce62615a469
+      - 17b95510-247d-4df4-976e-d1e9547b0e5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1668,18 +1982,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1692,9 +2006,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:43 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"76063bda19e87dae966904680cf5b6ee"
+      - W/"5233e514add985c864a224a9f3b49c6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1702,9 +2016,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "918"
+      - "881"
       X-Request-Id:
-      - f13a9cb6-1a5d-408e-8b6e-9904d9b05750
+      - e77215c0-46d4-44bf-afa4-4ec2f1305755
     status: 200 OK
     code: 200
     duration: ""
@@ -1716,12 +2030,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_u7ChXWznxpZm01zF
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JOJhTFtsqly6fUBI
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1736,9 +2050,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:43 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"459738fedd1020685cedb9eb48b3c044"
+      - W/"1c3c7befe5208605a8d42832e55aff04"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1746,9 +2060,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "880"
       X-Request-Id:
-      - df536dce-3357-4d4f-9119-24fa5f9365ff
+      - a943ca98-c37d-4ae3-8e6e-f6c3860616f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1760,18 +2074,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1784,9 +2098,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:43 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"76063bda19e87dae966904680cf5b6ee"
+      - W/"5233e514add985c864a224a9f3b49c6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1794,9 +2108,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "916"
+      - "879"
       X-Request-Id:
-      - 42c736ba-181a-4319-b466-11d979f5546f
+      - c41c1763-f625-40e0-9c68-2ab09234faed
     status: 200 OK
     code: 200
     duration: ""
@@ -1806,12 +2120,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_mJwJ591onNsL67hL","name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.255.130/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_1wmfJWRrQNGTqeDu","name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.174/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1826,9 +2140,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:43 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"045300df3cb9e1f1fe1c1fa10572c67b"
+      - W/"ddc6c529e125c569a19f216b09427e13"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1836,9 +2150,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "915"
+      - "878"
       X-Request-Id:
-      - 46f3ea9a-2882-4514-8caa-9e92a324cef7
+      - a24bab76-e61f-4c67-959a-80fe53c53070
     status: 200 OK
     code: 200
     duration: ""
@@ -1848,12 +2162,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1868,9 +2182,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:43 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1878,9 +2192,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "914"
+      - "877"
       X-Request-Id:
-      - 3811b909-a92a-4782-bf75-850155a7e9cd
+      - 4712cf03-acaf-47f5-a1db-41710d1996a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1892,12 +2206,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_mJwJ591onNsL67hL
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_1wmfJWRrQNGTqeDu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_mJwJ591onNsL67hL","virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx"},"name":"Public
-      Network on tf-acc-test-update-package-by-id-0kzocmfzomxx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:28:40:72:51:e2","state":"attached","ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1wmfJWRrQNGTqeDu","virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil"},"name":"Public
+      Network on tf-acc-test-update-package-by-id-8xzo1gqx9iil","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:c8:8b:aa:d8:44","state":"attached","ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1912,9 +2226,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:43 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"3b19d4a3ca6279e07df6b6e2cda1a37f"
+      - W/"c615867b50dfb7055756ea6c17a2a90f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1922,9 +2236,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "913"
+      - "876"
       X-Request-Id:
-      - 41618777-81d2-49df-b1ec-cc8916347f43
+      - 23e21e61-2273-4f03-a772-1aa963a7beeb
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,18 +2250,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1960,9 +2274,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:43 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"76063bda19e87dae966904680cf5b6ee"
+      - W/"5233e514add985c864a224a9f3b49c6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1970,9 +2284,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "912"
+      - "875"
       X-Request-Id:
-      - a98fcf78-99e7-48f5-9729-6aa3b7c4329d
+      - 2b76530e-675a-428b-96a0-29567d3c3b74
     status: 200 OK
     code: 200
     duration: ""
@@ -1984,10 +2298,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: POST
   response:
-    body: '{"task":{"id":"task_VGAnNvaCtZfTeGOh","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_U8KrCQXVUC36krpm","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2002,9 +2316,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:43 GMT
+      - Wed, 08 Jul 2026 18:43:53 GMT
       Etag:
-      - W/"18705219a3cdbcdd0b8a1d755329208f"
+      - W/"d0c18eceda43a5e3d32b296dfcf23b1d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2012,9 +2326,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "911"
+      - "874"
       X-Request-Id:
-      - 34886833-8e9c-4668-992e-c7e02b3122ae
+      - c3af48aa-9d49-45da-b0df-23e0832de077
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,10 +2340,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_VGAnNvaCtZfTeGOh
+    url: https://api.katapult.io/core/v1/tasks/task_U8KrCQXVUC36krpm
     method: GET
   response:
-    body: '{"task":{"id":"task_VGAnNvaCtZfTeGOh","name":"Stop virtual machine","status":"running","created_at":1780867183,"started_at":1780867184,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_U8KrCQXVUC36krpm","name":"Stop virtual machine","status":"pending","created_at":1783536233,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2040,13 +2354,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "162"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:44 GMT
+      - Wed, 08 Jul 2026 18:43:54 GMT
       Etag:
-      - W/"2d8ffedeb6c43090069c556866c0ef1c"
+      - W/"38b2f2245b02f1effb24c1df40f7b9f4"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2054,9 +2368,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "910"
+      - "873"
       X-Request-Id:
-      - 894651a4-104d-4e55-98d6-78bfb5f9162b
+      - f29a54af-46f5-4b64-8df1-868a4ad4ea8f
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,10 +2382,52 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_VGAnNvaCtZfTeGOh
+    url: https://api.katapult.io/core/v1/tasks/task_U8KrCQXVUC36krpm
     method: GET
   response:
-    body: '{"task":{"id":"task_VGAnNvaCtZfTeGOh","name":"Stop virtual machine","status":"completed","created_at":1780867183,"started_at":1780867184,"finished_at":1780867186,"progress":100}}'
+    body: '{"task":{"id":"task_U8KrCQXVUC36krpm","name":"Stop virtual machine","status":"running","created_at":1783536233,"started_at":1783536236,"finished_at":null,"progress":77}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "169"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:59 GMT
+      Etag:
+      - W/"6b0ed93fb25c804dbe93f88399b6cf0f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "871"
+      X-Request-Id:
+      - 49825c5f-6003-46c8-9871-5d2fb5463b6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_U8KrCQXVUC36krpm
+    method: GET
+  response:
+    body: '{"task":{"id":"task_U8KrCQXVUC36krpm","name":"Stop virtual machine","status":"completed","created_at":1783536233,"started_at":1783536236,"finished_at":1783536241,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2086,9 +2442,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:49 GMT
+      - Wed, 08 Jul 2026 18:44:09 GMT
       Etag:
-      - W/"e11967a12c2367923f0aa7860641af2d"
+      - W/"0f7f657efe2b14184aeef724f2611607"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2096,9 +2452,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "909"
+      - "987"
       X-Request-Id:
-      - 716c471d-bcb6-479c-9693-08435b3f51db
+      - be3e0a6b-beae-408b-ad67-a11be8be36e0
     status: 200 OK
     code: 200
     duration: ""
@@ -2110,18 +2466,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2134,9 +2490,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:50 GMT
+      - Wed, 08 Jul 2026 18:44:11 GMT
       Etag:
-      - W/"7679410f1b139566372b51c3b8509c03"
+      - W/"2016b7e90c98d84e8a28312467ba4452"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2144,9 +2500,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "908"
+      - "986"
       X-Request-Id:
-      - 84085bcd-2f4d-46a0-bc3f-403d5c0b49b5
+      - b58a829b-d9bf-44ae-b5a6-169d23fb9c1b
     status: 200 OK
     code: 200
     duration: ""
@@ -2158,18 +2514,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_VB7icKqKBUN0Sl4B","keep_until":1781039990,"object_id":"vm_k4CIel99LAJgFBLr","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_k4CIel99LAJgFBLr","name":"tf-acc-test-update-package-by-id-0kzocmfzomxx","hostname":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host","fqdn":"tf-acc-test-update-package-by-id-0kzocmfzomxx-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"vTpgdCccPyB1FNWO","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_56kThABTKGlDOoZ6","keep_until":1783709051,"object_id":"vm_ibeOKufPo1SHMkz8","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_ibeOKufPo1SHMkz8","name":"tf-acc-test-update-package-by-id-8xzo1gqx9iil","hostname":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host","fqdn":"tf-acc-test-update-package-by-id-8xzo1gqx9iil-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536167,"initial_root_password":"TmLXlG8ulbLBugJc","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_u7ChXWznxpZm01zF","address":"185.44.255.130","reverse_dns":"185-44-255-130.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.130/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JOJhTFtsqly6fUBI","address":"185.44.252.174","reverse_dns":"185-44-252-174.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.174/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_k4CIel99LAJgFBLr","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_ibeOKufPo1SHMkz8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2182,9 +2538,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:44:11 GMT
       Etag:
-      - W/"077ea244d2cdafc18579a61e795f8a94"
+      - W/"83cdb5b2e9998665cfae7a3efdaf047d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2192,9 +2548,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "907"
+      - "984"
       X-Request-Id:
-      - 51691e4f-e227-4c4a-b5ee-4e6683eaeed0
+      - 7271b076-b7c2-4334-8dc7-180cf249c036
     status: 200 OK
     code: 200
     duration: ""
@@ -2206,7 +2562,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_u7ChXWznxpZm01zF
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_JOJhTFtsqly6fUBI
     method: POST
   response:
     body: '{}'
@@ -2224,7 +2580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:44:12 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2234,9 +2590,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "904"
+      - "979"
       X-Request-Id:
-      - 6befbebd-2b07-4f10-a7d6-1ba56ba6eefb
+      - 3ed6fbce-b42d-474b-9c80-7cd1ca410e50
     status: 200 OK
     code: 200
     duration: ""
@@ -2248,10 +2604,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_ibeOKufPo1SHMkz8
     method: DELETE
   response:
-    body: '{"task":{"id":"task_a2LalYIT2e1RdTQT","name":"Purge items from trash","status":"pending","created_at":1780867191,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_pF2sRgf4C6qtIF33","name":"Purge items from trash","status":"pending","created_at":1783536252,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2266,9 +2622,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:44:12 GMT
       Etag:
-      - W/"4137c14c8b5d1d42c9cc5a1d3ebb8ebb"
+      - W/"91df5947fdc4ce4b9281dd5a8bab7ae6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2276,9 +2632,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "897"
+      - "978"
       X-Request-Id:
-      - 12bccfbb-d582-4d40-a4d8-c1fe8e9ffbc9
+      - 9cb21b01-5a0c-4692-b6af-8d353d4116e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2290,10 +2646,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_VB7icKqKBUN0Sl4B","keep_until":1781039990,"object_id":"vm_k4CIel99LAJgFBLr","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_56kThABTKGlDOoZ6","keep_until":1783709051,"object_id":"vm_ibeOKufPo1SHMkz8","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2308,9 +2664,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:52 GMT
+      - Wed, 08 Jul 2026 18:44:13 GMT
       Etag:
-      - W/"c42b896fa1981704aed3726e16cf6740"
+      - W/"6e10071905583a75c1d5ca8d958f6841"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2318,9 +2674,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "887"
+      - "977"
       X-Request-Id:
-      - 7a4d3166-93ba-4c56-ad4c-85bf564a8963
+      - 11f93bd2-f256-45bd-81c5-65792b2be1a5
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,7 +2688,91 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_ibeOKufPo1SHMkz8
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_56kThABTKGlDOoZ6","keep_until":1783709051,"object_id":"vm_ibeOKufPo1SHMkz8","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:44:18 GMT
+      Etag:
+      - W/"6e10071905583a75c1d5ca8d958f6841"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - acbe2ada-fd9a-4081-8a5a-ca76e907c5ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_ibeOKufPo1SHMkz8
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_56kThABTKGlDOoZ6","keep_until":1783709051,"object_id":"vm_ibeOKufPo1SHMkz8","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:44:28 GMT
+      Etag:
+      - W/"6e10071905583a75c1d5ca8d958f6841"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 5fcc102d-d292-414f-8c74-28e8a8fbb164
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2351,7 +2791,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:57 GMT
+      - Wed, 08 Jul 2026 18:44:38 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2361,9 +2801,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "882"
+      - "967"
       X-Request-Id:
-      - 66594b60-7f6e-450a-8a5c-01a798d02f5f
+      - d3139910-48d6-4644-948d-d7042d3a83ec
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2375,7 +2815,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_u7ChXWznxpZm01zF
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JOJhTFtsqly6fUBI
     method: DELETE
   response:
     body: '{}'
@@ -2393,7 +2833,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:57 GMT
+      - Wed, 08 Jul 2026 18:44:38 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2403,9 +2843,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "881"
+      - "966"
       X-Request-Id:
-      - 9a4a89a8-17ea-4ae5-9f34-f846921e8771
+      - 1ec78776-523a-4746-a8cb-4a7b28d054bc
     status: 200 OK
     code: 200
     duration: ""
@@ -2417,7 +2857,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2436,7 +2876,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:58 GMT
+      - Wed, 08 Jul 2026 18:44:38 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2446,9 +2886,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "880"
+      - "965"
       X-Request-Id:
-      - a10d4b6f-88ac-4194-b614-2d55f664c158
+      - ed44e413-9d07-4e43-bf00-11a2cd82533a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2460,7 +2900,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_k4CIel99LAJgFBLr
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_ibeOKufPo1SHMkz8
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2479,7 +2919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:58 GMT
+      - Wed, 08 Jul 2026 18:44:38 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2489,9 +2929,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "879"
+      - "964"
       X-Request-Id:
-      - fd364d93-ee5f-4210-98e2-a5380b262d91
+      - 8771bbac-88cc-4e81-8160-13de82e58cfd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2503,7 +2943,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_u7ChXWznxpZm01zF
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JOJhTFtsqly6fUBI
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2522,7 +2962,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:58 GMT
+      - Wed, 08 Jul 2026 18:44:38 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2532,9 +2972,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "878"
+      - "963"
       X-Request-Id:
-      - 54b9271f-2aa2-4a79-83c5-a4422ffb4429
+      - 2f949d37-736f-4b36-ac0f-f89cd8643e75
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_package_downgrade_error.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_package_downgrade_error.cassette.rand_id
@@ -1,1 +1,1 @@
-24wy9iuahs8p
+h2xq6b63l0sq

--- a/internal/provider/testdata/VirtualMachine_update_package_downgrade_error.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_package_downgrade_error.cassette.yaml
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:47 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -37,9 +37,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "998"
       X-Request-Id:
-      - 2291bd7e-7369-43ed-9b36-4372e66fb1a4
+      - 697c1e33-9553-4b8e-8c18-a189e97e987e
     status: 200 OK
     code: 200
     duration: ""
@@ -57,7 +57,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"185-44-254-2.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"185-44-254-111.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -70,13 +70,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "685"
+      - "691"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:48 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"cbc035b5359cf37af5ff6fc2a4b10c82"
+      - W/"f6ef590d205ccf781194879fedd054a1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -86,7 +86,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "994"
       X-Request-Id:
-      - 7d82b6f2-a517-46f7-a95e-2dced9921a4b
+      - acc86bef-0253-4f2b-8380-4d1302bddcb5
     status: 200 OK
     code: 200
     duration: ""
@@ -98,10 +98,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ozTt0lwZrxHHO17D
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JF6s7iUPXSTtXGdM
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"185-44-254-2.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"185-44-254-111.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -114,13 +114,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "703"
+      - "709"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:48 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"ccbf33c225a1579b02314352a125005a"
+      - W/"de8579e6784f9c501a99b4e5190cd185"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -130,7 +130,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - 843f2b8b-ceea-4c36-a63d-09b6d65bc181
+      - cea45bd9-2071-438d-9af7-73cfee04ee9a
     status: 200 OK
     code: 200
     duration: ""
@@ -142,10 +142,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ozTt0lwZrxHHO17D
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JF6s7iUPXSTtXGdM
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"185-44-254-2.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"185-44-254-111.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -158,13 +158,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "703"
+      - "709"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:48 GMT
+      - Wed, 08 Jul 2026 18:42:39 GMT
       Etag:
-      - W/"ccbf33c225a1579b02314352a125005a"
+      - W/"de8579e6784f9c501a99b4e5190cd185"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -174,13 +174,13 @@ interactions:
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - e7d37248-2f2f-4b07-95c5-732ba77c973f
+      - 1dd7f1d4-a20a-4d7d-ad72-74cf7cfe506e
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_ozTt0lwZrxHHO17D</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host</Hostname></Hostname><Name>tf-acc-test-update-package-downgrade-error-24wy9iuahs8p</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_JF6s7iUPXSTtXGdM</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host</Hostname></Hostname><Name>tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -192,7 +192,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_7iW2bSb0lGVONoL6","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_mM4U9sDtDmnKpVbT","state":"pending"},"virtual_machine_build":{"id":"vmbuild_mM4U9sDtDmnKpVbT","state":"pending"},"hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","annotations":[]}'
+    body: '{"task":{"id":"task_CwkHGecF7QutRp9u","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_6vRolwxtINurXClm","state":"pending"},"virtual_machine_build":{"id":"vmbuild_6vRolwxtINurXClm","state":"pending"},"hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -207,9 +207,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:48 GMT
+      - Wed, 08 Jul 2026 18:42:40 GMT
       Etag:
-      - W/"d7eb7bcfdfeaf0c0cf34e2c031ae94cc"
+      - W/"8be2ae2eb850d1eb47d3debe6ca16a79"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -219,7 +219,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - 274bf30f-9b8d-4741-a474-0f6692f0c43c
+      - a4ab38e8-3f68-48da-a36d-cccc06bf9e52
     status: 201 Created
     code: 201
     duration: ""
@@ -231,17 +231,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mM4U9sDtDmnKpVbT
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6vRolwxtINurXClm
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mM4U9sDtDmnKpVbT","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_6vRolwxtINurXClm","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.2\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.111\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1780867128},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -254,9 +254,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:50 GMT
+      - Wed, 08 Jul 2026 18:42:42 GMT
       Etag:
-      - W/"179ff45dbab1fab43f309354f175a9c9"
+      - W/"a9162127088dbe89dc5d4c2183635156"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -264,9 +264,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "982"
+      - "983"
       X-Request-Id:
-      - 5f44cbbc-c418-41e4-8ad4-725c90e292c1
+      - 857a944f-b693-4ae6-ae6c-517fda383b9e
     status: 200 OK
     code: 200
     duration: ""
@@ -278,17 +278,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mM4U9sDtDmnKpVbT
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6vRolwxtINurXClm
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mM4U9sDtDmnKpVbT","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_6vRolwxtINurXClm","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.2\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.111\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1780867128},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -301,9 +301,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:18:55 GMT
+      - Wed, 08 Jul 2026 18:42:47 GMT
       Etag:
-      - W/"bb990aee322bd860e4dcce63b31cbf49"
+      - W/"a9162127088dbe89dc5d4c2183635156"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -311,9 +311,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "979"
+      - "980"
       X-Request-Id:
-      - 3159376c-7498-4a2e-886e-4566754960c2
+      - 7f9eb4ac-6c04-499e-8ce9-584fe36ab492
     status: 200 OK
     code: 200
     duration: ""
@@ -325,17 +325,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mM4U9sDtDmnKpVbT
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6vRolwxtINurXClm
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mM4U9sDtDmnKpVbT","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_6vRolwxtINurXClm","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.2\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.111\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1780867128},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783536159},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -348,151 +348,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:05 GMT
+      - Wed, 08 Jul 2026 18:42:57 GMT
       Etag:
-      - W/"bb990aee322bd860e4dcce63b31cbf49"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - 4730b734-205c-4127-ba41-6ffa9f68bc73
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mM4U9sDtDmnKpVbT
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mM4U9sDtDmnKpVbT","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.2\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p\u003c/Name\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1780867128},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:15 GMT
-      Etag:
-      - W/"bb990aee322bd860e4dcce63b31cbf49"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - 3f967315-8449-42fc-99bc-3c05e3206781
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mM4U9sDtDmnKpVbT
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mM4U9sDtDmnKpVbT","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.2\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-24wy9iuahs8p\u003c/Name\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1780867128},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:25 GMT
-      Etag:
-      - W/"269bf49e65a09f6a3714a5359b51f9c9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "982"
-      X-Request-Id:
-      - 53de2a26-8007-4b5e-8ec7-0d07602cc62c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:27 GMT
-      Etag:
-      - W/"49db8672551e030777070fc1ebf83276"
+      - W/"bb35efca28e3b23ed6787833c233a0b0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -502,7 +360,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "969"
       X-Request-Id:
-      - 49404443-fa98-45eb-a715-962bf6288a41
+      - 531a9946-d8d5-40b6-897f-32e9294fa5ff
     status: 200 OK
     code: 200
     duration: ""
@@ -514,18 +372,206 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6vRolwxtINurXClm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine_build":{"id":"vmbuild_6vRolwxtINurXClm","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.111\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783536159},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:07 GMT
+      Etag:
+      - W/"bb35efca28e3b23ed6787833c233a0b0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - ef89299f-2aa0-4bac-bfc0-9e381a75a38f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6vRolwxtINurXClm
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_6vRolwxtINurXClm","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.111\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783536159},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:17 GMT
+      Etag:
+      - W/"bb35efca28e3b23ed6787833c233a0b0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - bea180c8-18c6-46e8-be89-bcc6b62bae38
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6vRolwxtINurXClm
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_6vRolwxtINurXClm","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.111\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783536159},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:27 GMT
+      Etag:
+      - W/"bb35efca28e3b23ed6787833c233a0b0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - a8d814bd-4f13-4f3b-ad26-50f5ab228149
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6vRolwxtINurXClm
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_6vRolwxtINurXClm","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.111\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-error-h2xq6b63l0sq\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1783536159},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:37 GMT
+      Etag:
+      - W/"7cc01f370e5d3a9713d21af05c21b370"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "927"
+      X-Request-Id:
+      - 480f9d15-96c0-4169-8c4f-07c7981ffb90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"starting","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -538,9 +584,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:32 GMT
+      - Wed, 08 Jul 2026 18:43:39 GMT
       Etag:
-      - W/"84feff83baa8b0559838845fc93cdd84"
+      - W/"5ed7d7ad21b0c671c1c7b3c7e5987db5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -548,9 +594,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "926"
       X-Request-Id:
-      - 2e7cc4b1-df43-4bdb-a19b-cdee27bd19b6
+      - f24dde74-00ab-4229-acf8-2ee510058331
     status: 200 OK
     code: 200
     duration: ""
@@ -562,18 +608,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -586,9 +632,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:32 GMT
+      - Wed, 08 Jul 2026 18:43:44 GMT
       Etag:
-      - W/"84feff83baa8b0559838845fc93cdd84"
+      - W/"aec25feae50df891c888deace463f89c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -596,93 +642,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "924"
       X-Request-Id:
-      - 0f395305-fc3c-46bd-92da-8f8409d5e431
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_7kyHG79XK10OaYrG","name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.2/22"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "553"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
-      Etag:
-      - W/"ef30b5d8545b6eed0a7cb2474ed3ec8e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "960"
-      X-Request-Id:
-      - 3e321b65-bfc8-419a-ae7c-21a907bc4fc6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_7kyHG79XK10OaYrG
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_7kyHG79XK10OaYrG","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p"},"name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:d6:95:e8:a6:d1","state":"attached","ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "559"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
-      Etag:
-      - W/"c2685a87bba30300c1d148ab77768b79"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "958"
-      X-Request-Id:
-      - b9b655c7-b02f-4465-b056-ef4add937ea1
+      - a93f2ff9-2348-483b-81f5-e9609008d6ce
     status: 200 OK
     code: 200
     duration: ""
@@ -694,12 +656,58 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_7kyHG79XK10OaYrG
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_7kyHG79XK10OaYrG","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p"},"name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:d6:95:e8:a6:d1","state":"attached","ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:44 GMT
+      Etag:
+      - W/"aec25feae50df891c888deace463f89c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "923"
+      X-Request-Id:
+      - 7f33fb6e-1d24-4cba-a620-7405d673565a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Ki5wmTyDPWV8EMR8","name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.111/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -710,13 +718,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "559"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:44 GMT
       Etag:
-      - W/"c2685a87bba30300c1d148ab77768b79"
+      - W/"c20821dc94fc26fcbe062fa595aaa685"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -724,9 +732,95 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "922"
       X-Request-Id:
-      - 64757d24-52a0-4ed5-866e-03d05db0c502
+      - 5026d888-ebcd-4a31-812a-ff8a2147b19b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Ki5wmTyDPWV8EMR8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ki5wmTyDPWV8EMR8","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:02:66:1a:08:a9","state":"attached","ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "561"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:44 GMT
+      Etag:
+      - W/"febaabd6b0b6f059356a61e0749ce571"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "921"
+      X-Request-Id:
+      - c44cc6e4-b4ae-425c-aa6c-39e726f3f2ec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Ki5wmTyDPWV8EMR8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ki5wmTyDPWV8EMR8","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:02:66:1a:08:a9","state":"attached","ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "561"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 08 Jul 2026 18:43:44 GMT
+      Etag:
+      - W/"febaabd6b0b6f059356a61e0749ce571"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "920"
+      X-Request-Id:
+      - 307c190a-d5ad-4bb9-9edf-0d5e5247e2a1
     status: 200 OK
     code: 200
     duration: ""
@@ -738,18 +832,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -762,9 +856,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:44 GMT
       Etag:
-      - W/"84feff83baa8b0559838845fc93cdd84"
+      - W/"aec25feae50df891c888deace463f89c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -772,9 +866,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "919"
       X-Request-Id:
-      - ea04958d-a7fe-4f3d-8cc6-e0d28a0c64b4
+      - fe1b2862-49b6-4f1f-a8fd-67aca8f4eb1f
     status: 200 OK
     code: 200
     duration: ""
@@ -786,12 +880,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ozTt0lwZrxHHO17D
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JF6s7iUPXSTtXGdM
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -802,13 +896,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "920"
+      - "924"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"8900ad3c142e617ad9037e499ffd3159"
+      - W/"3ba7179d04d97103e3f2543f23059ce5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -816,9 +910,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "951"
+      - "918"
       X-Request-Id:
-      - 131439ac-e519-48fe-813f-c7a49b271fce
+      - 3820a416-a852-40c8-b3f9-eeb032ee9886
     status: 200 OK
     code: 200
     duration: ""
@@ -830,18 +924,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -854,9 +948,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"84feff83baa8b0559838845fc93cdd84"
+      - W/"aec25feae50df891c888deace463f89c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -864,9 +958,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "949"
+      - "917"
       X-Request-Id:
-      - e8d6aa10-5954-4927-a3ee-7a0a653cf168
+      - 2e3814f1-8e94-4a61-9524-4aebc5613ac0
     status: 200 OK
     code: 200
     duration: ""
@@ -876,12 +970,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_7kyHG79XK10OaYrG","name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.2/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Ki5wmTyDPWV8EMR8","name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.111/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -892,13 +986,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "553"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"ef30b5d8545b6eed0a7cb2474ed3ec8e"
+      - W/"c20821dc94fc26fcbe062fa595aaa685"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -906,9 +1000,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "916"
       X-Request-Id:
-      - 39f7eaef-5679-460a-b0d0-cd71c55403bd
+      - 2084554f-11bc-47e8-ae3d-b1db696fbaf5
     status: 200 OK
     code: 200
     duration: ""
@@ -918,12 +1012,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_7kyHG79XK10OaYrG
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Ki5wmTyDPWV8EMR8
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_7kyHG79XK10OaYrG","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p"},"name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:d6:95:e8:a6:d1","state":"attached","ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ki5wmTyDPWV8EMR8","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:02:66:1a:08:a9","state":"attached","ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -934,13 +1028,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "559"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"c2685a87bba30300c1d148ab77768b79"
+      - W/"febaabd6b0b6f059356a61e0749ce571"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -948,9 +1042,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "947"
+      - "915"
       X-Request-Id:
-      - 72920c56-e3fd-4df0-aeb3-cb8e94db9465
+      - c2f58386-9635-450f-817a-dbee75ba841b
     status: 200 OK
     code: 200
     duration: ""
@@ -962,12 +1056,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_7kyHG79XK10OaYrG
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Ki5wmTyDPWV8EMR8
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_7kyHG79XK10OaYrG","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p"},"name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:d6:95:e8:a6:d1","state":"attached","ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ki5wmTyDPWV8EMR8","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:02:66:1a:08:a9","state":"attached","ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -978,13 +1072,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "559"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"c2685a87bba30300c1d148ab77768b79"
+      - W/"febaabd6b0b6f059356a61e0749ce571"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -992,9 +1086,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "945"
+      - "914"
       X-Request-Id:
-      - 378ca3f9-1a82-424a-97ee-380e91dad4a3
+      - c54c4ebe-3999-4e91-95b3-41565c2d9fe8
     status: 200 OK
     code: 200
     duration: ""
@@ -1006,12 +1100,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ozTt0lwZrxHHO17D
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JF6s7iUPXSTtXGdM
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1022,13 +1116,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "920"
+      - "924"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"8900ad3c142e617ad9037e499ffd3159"
+      - W/"3ba7179d04d97103e3f2543f23059ce5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1036,9 +1130,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "913"
       X-Request-Id:
-      - c642379b-404c-417d-9b45-53aeaa38983e
+      - 8891cc4c-bda1-4e18-86cc-2d97f3e315f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1050,18 +1144,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1074,9 +1168,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"84feff83baa8b0559838845fc93cdd84"
+      - W/"aec25feae50df891c888deace463f89c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1084,9 +1178,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "939"
+      - "912"
       X-Request-Id:
-      - 1d5d39cb-d934-4cc9-96d5-6c0634c5d497
+      - 23890220-0005-4ddd-b374-8aec090bb51f
     status: 200 OK
     code: 200
     duration: ""
@@ -1096,12 +1190,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_7kyHG79XK10OaYrG","name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.2/22"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Ki5wmTyDPWV8EMR8","name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.254.111/22"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1112,13 +1206,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "553"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"ef30b5d8545b6eed0a7cb2474ed3ec8e"
+      - W/"c20821dc94fc26fcbe062fa595aaa685"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1126,9 +1220,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "938"
+      - "911"
       X-Request-Id:
-      - d5942b6c-2e71-43b8-baac-e8c74446c0f4
+      - 1d02fb9d-8920-4fea-88c2-95919da2c09e
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,12 +1232,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_7kyHG79XK10OaYrG
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Ki5wmTyDPWV8EMR8
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_7kyHG79XK10OaYrG","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p"},"name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:d6:95:e8:a6:d1","state":"attached","ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ki5wmTyDPWV8EMR8","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:02:66:1a:08:a9","state":"attached","ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1154,13 +1248,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "559"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"c2685a87bba30300c1d148ab77768b79"
+      - W/"febaabd6b0b6f059356a61e0749ce571"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1168,9 +1262,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "936"
+      - "910"
       X-Request-Id:
-      - edbc26c6-257d-49ed-9dbe-1ee6447b1629
+      - 5115aa16-a6ca-41da-8042-25265af271d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1182,12 +1276,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_7kyHG79XK10OaYrG
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Ki5wmTyDPWV8EMR8
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_7kyHG79XK10OaYrG","virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p"},"name":"Public
-      Network on tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:d6:95:e8:a6:d1","state":"attached","ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ki5wmTyDPWV8EMR8","virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:02:66:1a:08:a9","state":"attached","ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1198,13 +1292,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "559"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:33 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"c2685a87bba30300c1d148ab77768b79"
+      - W/"febaabd6b0b6f059356a61e0749ce571"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1212,9 +1306,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "935"
+      - "909"
       X-Request-Id:
-      - 08387a67-cb3e-415c-9614-85e1ef0197a0
+      - 770a63ce-817a-4c62-b810-f07d3937fa37
     status: 200 OK
     code: 200
     duration: ""
@@ -1226,18 +1320,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1250,9 +1344,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:34 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
-      - W/"84feff83baa8b0559838845fc93cdd84"
+      - W/"aec25feae50df891c888deace463f89c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1260,9 +1354,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "932"
+      - "908"
       X-Request-Id:
-      - 88fedd09-6149-4f7c-a254-e0441466dd02
+      - 8ef4f8ef-def7-420a-ab84-d50f9d4175a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1293,7 +1387,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:34 GMT
+      - Wed, 08 Jul 2026 18:43:45 GMT
       Etag:
       - W/"858692638091f36cd41151d389dfdb44"
       Strict-Transport-Security:
@@ -1303,9 +1397,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "931"
+      - "907"
       X-Request-Id:
-      - f38d8f6a-5c44-4a32-a76b-f684f278ad7f
+      - 95cbac46-300f-4597-b4e0-a073d37cf8d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1317,18 +1411,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1341,9 +1435,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:34 GMT
+      - Wed, 08 Jul 2026 18:43:46 GMT
       Etag:
-      - W/"84feff83baa8b0559838845fc93cdd84"
+      - W/"aec25feae50df891c888deace463f89c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1351,9 +1445,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "930"
+      - "906"
       X-Request-Id:
-      - a1ac0f12-6de6-42c8-8a5a-2770522ab616
+      - 0923ade9-cf0d-47f4-869c-4ea35689f6e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1365,10 +1459,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: POST
   response:
-    body: '{"task":{"id":"task_BOH1CWFE8f8e4ZfT","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_pPhBuppShoxrpJ3z","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1383,9 +1477,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:35 GMT
+      - Wed, 08 Jul 2026 18:43:46 GMT
       Etag:
-      - W/"6dd29ba538179b4e427166fb6dba2760"
+      - W/"804c34f1ec616c7fe6778212b5ddf3e9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1393,9 +1487,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "929"
+      - "905"
       X-Request-Id:
-      - a0e9f977-2afd-48c0-be06-93c41d143527
+      - 18353a52-a763-4722-b509-ed0ee27405a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1407,10 +1501,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_BOH1CWFE8f8e4ZfT
+    url: https://api.katapult.io/core/v1/tasks/task_pPhBuppShoxrpJ3z
     method: GET
   response:
-    body: '{"task":{"id":"task_BOH1CWFE8f8e4ZfT","name":"Stop virtual machine","status":"pending","created_at":1780867174,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_pPhBuppShoxrpJ3z","name":"Stop virtual machine","status":"pending","created_at":1783536226,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1425,9 +1519,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:36 GMT
+      - Wed, 08 Jul 2026 18:43:47 GMT
       Etag:
-      - W/"76aa109c09a5e1dda7fcef61de1ceeb0"
+      - W/"77cbdfc2091200c774b820a8e6f7e147"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1435,9 +1529,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "928"
+      - "904"
       X-Request-Id:
-      - 77223c44-7d4b-4433-aec3-c1877abada14
+      - df1bb564-ac8c-4123-b975-1afcd8347641
     status: 200 OK
     code: 200
     duration: ""
@@ -1449,10 +1543,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_BOH1CWFE8f8e4ZfT
+    url: https://api.katapult.io/core/v1/tasks/task_pPhBuppShoxrpJ3z
     method: GET
   response:
-    body: '{"task":{"id":"task_BOH1CWFE8f8e4ZfT","name":"Stop virtual machine","status":"running","created_at":1780867174,"started_at":1780867179,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_pPhBuppShoxrpJ3z","name":"Stop virtual machine","status":"running","created_at":1783536226,"started_at":1783536229,"finished_at":null,"progress":29}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1463,13 +1557,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "169"
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:41 GMT
+      - Wed, 08 Jul 2026 18:43:52 GMT
       Etag:
-      - W/"e52ac9c79351ba1031d72810c3342205"
+      - W/"bbece59af01e96f654bcc8c24ac6f4e1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1477,9 +1571,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "926"
+      - "888"
       X-Request-Id:
-      - 32d319d7-d373-46ae-a1fc-9784276c6be5
+      - c9c7eaff-a6d3-417f-971c-9e22f19a3abd
     status: 200 OK
     code: 200
     duration: ""
@@ -1491,10 +1585,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_BOH1CWFE8f8e4ZfT
+    url: https://api.katapult.io/core/v1/tasks/task_pPhBuppShoxrpJ3z
     method: GET
   response:
-    body: '{"task":{"id":"task_BOH1CWFE8f8e4ZfT","name":"Stop virtual machine","status":"completed","created_at":1780867174,"started_at":1780867179,"finished_at":1780867182,"progress":100}}'
+    body: '{"task":{"id":"task_pPhBuppShoxrpJ3z","name":"Stop virtual machine","status":"completed","created_at":1783536226,"started_at":1783536229,"finished_at":1783536234,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1509,9 +1603,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:51 GMT
+      - Wed, 08 Jul 2026 18:44:02 GMT
       Etag:
-      - W/"5bdbc076153fe0e63c415581fa656183"
+      - W/"b514090eddcf7d939027ea5585ccd85a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1519,9 +1613,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "905"
+      - "999"
       X-Request-Id:
-      - d9b46b41-40a4-44c8-8023-b4064d873b7b
+      - 7e61021b-4ea5-4a27-82ac-7e813ededbfd
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,18 +1627,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1557,9 +1651,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:52 GMT
+      - Wed, 08 Jul 2026 18:44:03 GMT
       Etag:
-      - W/"6df2ec0e0091914aa5f6127ecf4941ed"
+      - W/"43dda71499639d08ff05d6c9aa01f3cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1567,9 +1661,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "889"
+      - "998"
       X-Request-Id:
-      - d8fa370f-afb9-4501-949c-260d2fa8e3ab
+      - b3499253-242e-449d-9c24-2ee8a8e87ba6
     status: 200 OK
     code: 200
     duration: ""
@@ -1581,18 +1675,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_TqZc1PtHjuTxG4Ks","keep_until":1781039992,"object_id":"vm_vRB5R0yCvdphzdg7","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_vRB5R0yCvdphzdg7","name":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p","hostname":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host","fqdn":"tf-acc-test-update-package-downgrade-error-24wy9iuahs8p-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1780867132,"initial_root_password":"ffRpPywS8TexmTCy","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_47VaZmSDhU3CALNH","keep_until":1783709043,"object_id":"vm_hPKFWKCwDjiX2hIv","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_hPKFWKCwDjiX2hIv","name":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq","hostname":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host","fqdn":"tf-acc-test-update-package-downgrade-error-h2xq6b63l0sq-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783536174,"initial_root_password":"JcUj0rbYi4V4Pqy4","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ozTt0lwZrxHHO17D","address":"185.44.254.2","reverse_dns":"185-44-254-2.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.2/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_JF6s7iUPXSTtXGdM","address":"185.44.254.111","reverse_dns":"185-44-254-111.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.111/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_vRB5R0yCvdphzdg7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_hPKFWKCwDjiX2hIv","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1605,9 +1699,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:52 GMT
+      - Wed, 08 Jul 2026 18:44:04 GMT
       Etag:
-      - W/"bf55ace62a7fde5d418bba42b87018a3"
+      - W/"c49dd359da00ddc78f2540eabcdf9ed7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1615,9 +1709,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "888"
+      - "997"
       X-Request-Id:
-      - b838729b-3f22-48e2-84f9-b02bf57efc69
+      - d376d4a2-5532-435d-8b22-c992e4a2a0a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1629,7 +1723,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ozTt0lwZrxHHO17D
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_JF6s7iUPXSTtXGdM
     method: POST
   response:
     body: '{}'
@@ -1647,7 +1741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:53 GMT
+      - Wed, 08 Jul 2026 18:44:04 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -1657,9 +1751,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "886"
+      - "996"
       X-Request-Id:
-      - 791a3ebf-3410-429a-8390-724e0878659f
+      - bb7f12ba-8fd2-4162-9b03-5f8207f94f94
     status: 200 OK
     code: 200
     duration: ""
@@ -1671,10 +1765,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hPKFWKCwDjiX2hIv
     method: DELETE
   response:
-    body: '{"task":{"id":"task_bx6V7XkNrwFC47qz","name":"Purge items from trash","status":"pending","created_at":1780867193,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_pxPzbsEdLTnoKqBG","name":"Purge items from trash","status":"pending","created_at":1783536244,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1689,9 +1783,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:53 GMT
+      - Wed, 08 Jul 2026 18:44:04 GMT
       Etag:
-      - W/"a0022ae0dcce4ee759e6dfd57ac986ab"
+      - W/"e16e3a75cc2d2ab8f9c930470583e3d7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1699,9 +1793,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "884"
+      - "995"
       X-Request-Id:
-      - 9d781a04-76f4-4170-ab8c-0366f7e1b6aa
+      - 96f14254-0165-4951-8286-9c6c97b61304
     status: 200 OK
     code: 200
     duration: ""
@@ -1713,10 +1807,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_TqZc1PtHjuTxG4Ks","keep_until":1781039992,"object_id":"vm_vRB5R0yCvdphzdg7","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_47VaZmSDhU3CALNH","keep_until":1783709043,"object_id":"vm_hPKFWKCwDjiX2hIv","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1731,9 +1825,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:19:54 GMT
+      - Wed, 08 Jul 2026 18:44:06 GMT
       Etag:
-      - W/"ef39530bb9793fda2d99e4baf65602a0"
+      - W/"22445f7c82a0518cc5b9342c6e644f19"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1741,9 +1835,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "883"
+      - "992"
       X-Request-Id:
-      - e33855bf-e0ca-417c-ac96-fc1adf909816
+      - 8abebc2c-b6dc-404b-b349-940f8bd7b8fe
     status: 200 OK
     code: 200
     duration: ""
@@ -1755,133 +1849,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_vRB5R0yCvdphzdg7
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_TqZc1PtHjuTxG4Ks","keep_until":1781039992,"object_id":"vm_vRB5R0yCvdphzdg7","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:19:59 GMT
-      Etag:
-      - W/"ef39530bb9793fda2d99e4baf65602a0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "874"
-      X-Request-Id:
-      - 0047b6ed-f3c5-4b5a-9c8c-2dae1932b500
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_vRB5R0yCvdphzdg7
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_TqZc1PtHjuTxG4Ks","keep_until":1781039992,"object_id":"vm_vRB5R0yCvdphzdg7","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:20:09 GMT
-      Etag:
-      - W/"ef39530bb9793fda2d99e4baf65602a0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 8165a496-6117-4d91-a97f-476cf22444cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_vRB5R0yCvdphzdg7
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_TqZc1PtHjuTxG4Ks","keep_until":1781039992,"object_id":"vm_vRB5R0yCvdphzdg7","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 07 Jun 2026 21:20:19 GMT
-      Etag:
-      - W/"ef39530bb9793fda2d99e4baf65602a0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - bfe40766-2dee-409b-b156-8d9259a0ee91
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -1900,7 +1868,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:29 GMT
+      - Wed, 08 Jul 2026 18:44:11 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1910,9 +1878,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "985"
       X-Request-Id:
-      - 13ce5bfd-24d5-4689-a13a-97c7e6441831
+      - 7b48a801-98c6-4f60-bc5f-5cde73b0e352
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1924,7 +1892,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ozTt0lwZrxHHO17D
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JF6s7iUPXSTtXGdM
     method: DELETE
   response:
     body: '{}'
@@ -1942,7 +1910,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:29 GMT
+      - Wed, 08 Jul 2026 18:44:11 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -1952,9 +1920,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "983"
       X-Request-Id:
-      - 3d1db0f5-4ecb-4708-b7e3-363c6e4e69ee
+      - 4d83b107-f84b-4a16-9637-4b34f3df2917
     status: 200 OK
     code: 200
     duration: ""
@@ -1966,7 +1934,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1985,7 +1953,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:29 GMT
+      - Wed, 08 Jul 2026 18:44:11 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1995,9 +1963,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "982"
       X-Request-Id:
-      - cf5847a1-e5ee-492b-ad90-6c734dc52665
+      - fbb1c6a4-afc6-4a76-a52c-f9a9e4f2e66b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2009,7 +1977,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_vRB5R0yCvdphzdg7
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hPKFWKCwDjiX2hIv
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2028,7 +1996,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:29 GMT
+      - Wed, 08 Jul 2026 18:44:11 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2038,9 +2006,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "981"
       X-Request-Id:
-      - 66620193-2f38-4905-ba7b-a875f205f15c
+      - a4611cc5-c718-4362-b5a9-1b1b7a1f3c55
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2052,7 +2020,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ozTt0lwZrxHHO17D
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JF6s7iUPXSTtXGdM
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2071,7 +2039,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sun, 07 Jun 2026 21:20:29 GMT
+      - Wed, 08 Jul 2026 18:44:11 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2081,9 +2049,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "980"
       X-Request-Id:
-      - 2b3bf33e-0695-4eb5-9617-6a1deb5da054
+      - 67d7596d-971c-41b9-807b-33f198b295b4
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_package_downgrade_stopped.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_package_downgrade_stopped.cassette.rand_id
@@ -1,0 +1,1 @@
+f9nwpwdteezb

--- a/internal/provider/testdata/VirtualMachine_update_package_downgrade_stopped.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_package_downgrade_stopped.cassette.yaml
@@ -1,0 +1,2730 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
+    method: GET
+  response:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "196"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - a727eb83-f99d-4f2c-b8eb-a53d136e54db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"185-44-253-33.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "688"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"d1d6911aed9e9c7c2523bd3a2db3d95f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - a2a9491c-f6fa-4345-a59b-7fa64b4cdf22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ZcuSWwk99q1f62vi
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"185-44-253-33.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "706"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"2f240f9680b44f0d5ad6584af46a2811"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 52a217df-e701-439c-99ad-a7cdf917a26e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ZcuSWwk99q1f62vi
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"185-44-253-33.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "706"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"2f240f9680b44f0d5ad6584af46a2811"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 11265d87-1561-45d6-a3e5-6ed7a84e472d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_ZcuSWwk99q1f62vi</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host</Hostname></Hostname><Name>tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
+    method: POST
+  response:
+    body: '{"task":{"id":"task_fXlLkwoBGVNpzGrE","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_VsDJqfMH3uuLVVSr","state":"pending"},"virtual_machine_build":{"id":"vmbuild_VsDJqfMH3uuLVVSr","state":"pending"},"hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "318"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"67f815f636ed51d0462ec342c60c2cb2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 418e79bc-11c3-4588-beea-777ce954c87b
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VsDJqfMH3uuLVVSr
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VsDJqfMH3uuLVVSr","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.33\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:11 GMT
+      Etag:
+      - W/"c98dc9d8aab3856a57abbc5b21c5a166"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 5ebf3d36-493a-4726-9ee7-091f880ab71d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VsDJqfMH3uuLVVSr
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VsDJqfMH3uuLVVSr","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.33\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:16 GMT
+      Etag:
+      - W/"871093507397fcb07c2212b0b8769ac3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 84945f61-e97b-4244-95af-73599efc8571
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VsDJqfMH3uuLVVSr
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VsDJqfMH3uuLVVSr","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.33\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:26 GMT
+      Etag:
+      - W/"871093507397fcb07c2212b0b8769ac3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - d8b8e97f-4a8c-4858-9ff5-73789f6a3832
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VsDJqfMH3uuLVVSr
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VsDJqfMH3uuLVVSr","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.33\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:36 GMT
+      Etag:
+      - W/"871093507397fcb07c2212b0b8769ac3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - e0ef3dae-610d-4656-866e-7e9a335a06cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VsDJqfMH3uuLVVSr
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VsDJqfMH3uuLVVSr","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.33\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:46 GMT
+      Etag:
+      - W/"9801a89dc1110ee65b349c648aed1d05"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 3ff9d6f0-f2db-4d10-9d79-b6219a641045
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"starting","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:48 GMT
+      Etag:
+      - W/"2dc871bae3f066ed4d4b9f16900343f8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 6b1dd655-f1c7-4e6f-aef7-23e317e63e7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"e3524c3c96af05f39202b28594042477"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "953"
+      X-Request-Id:
+      - 9be61433-dbf6-4f10-a91c-12cb320e6b9c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"e3524c3c96af05f39202b28594042477"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - 037620f0-14bc-45bf-9366-b3be85e92666
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tHkfaytEDikNKan4","name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.253.33/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"1f1c9f0e092adb2d241cb4972c81f881"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "951"
+      X-Request-Id:
+      - 00a97e7d-af27-4d36-b1a9-8778b8a096b9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"attached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"68d32c57a4181f7745d0248f2860f42b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "950"
+      X-Request-Id:
+      - 6885f907-bad1-46bd-8e05-ed5ca2b4ac56
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"attached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"68d32c57a4181f7745d0248f2860f42b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "949"
+      X-Request-Id:
+      - 620c1821-b007-4ce9-9deb-770892c1795a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"e3524c3c96af05f39202b28594042477"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - ee674b0e-038a-4562-a180-bcdcb7a8b948
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ZcuSWwk99q1f62vi
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "926"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"6ca004cf4f42296217ffc7d260788eaa"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - 64df3ae4-b7e2-440a-b77d-c8d6b2f7b5b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"e3524c3c96af05f39202b28594042477"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 63948794-4e5b-4d16-997e-4612239608e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tHkfaytEDikNKan4","name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.253.33/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"1f1c9f0e092adb2d241cb4972c81f881"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - 99574de3-9fd7-4ef6-b2ac-830beb174a8c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"attached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"68d32c57a4181f7745d0248f2860f42b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - 7aae5560-17c1-4bd4-bbc5-9b032e0e69c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"attached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"68d32c57a4181f7745d0248f2860f42b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - e8722461-817a-4da6-a150-1f241e446358
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: POST
+  response:
+    body: '{"task":{"id":"task_GyFRhNHRWyTBqAu6","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:54 GMT
+      Etag:
+      - W/"6453961a6e6b2ec9ba035abf35632db6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "941"
+      X-Request-Id:
+      - 911ba73d-729a-44dd-b2da-54c32e59bfae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_GyFRhNHRWyTBqAu6
+    method: GET
+  response:
+    body: '{"task":{"id":"task_GyFRhNHRWyTBqAu6","name":"Stop virtual machine","status":"pending","created_at":1783600674,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:55 GMT
+      Etag:
+      - W/"1d8fce800c90d762129d37989a88e00e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "940"
+      X-Request-Id:
+      - 5c2862ba-5bbd-4322-a84c-2f1b9f33a9a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_GyFRhNHRWyTBqAu6
+    method: GET
+  response:
+    body: '{"task":{"id":"task_GyFRhNHRWyTBqAu6","name":"Stop virtual machine","status":"pending","created_at":1783600674,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:00 GMT
+      Etag:
+      - W/"1d8fce800c90d762129d37989a88e00e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 80fc6a0a-1e70-430f-9d6c-047f3f42a8fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_GyFRhNHRWyTBqAu6
+    method: GET
+  response:
+    body: '{"task":{"id":"task_GyFRhNHRWyTBqAu6","name":"Stop virtual machine","status":"pending","created_at":1783600674,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:10 GMT
+      Etag:
+      - W/"1d8fce800c90d762129d37989a88e00e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 315f5553-d882-4fcf-9792-6710cb7ccb7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_GyFRhNHRWyTBqAu6
+    method: GET
+  response:
+    body: '{"task":{"id":"task_GyFRhNHRWyTBqAu6","name":"Stop virtual machine","status":"completed","created_at":1783600674,"started_at":1783600691,"finished_at":1783600693,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:20 GMT
+      Etag:
+      - W/"a9b34d4f7c1e9460463d82186a439769"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 00fe71d6-6842-43bb-9d7c-d71cc916bda2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:21 GMT
+      Etag:
+      - W/"851ba9ad227c22385f39e89b4e44cbbf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - a4c35816-12ab-465f-adb1-196d3ce86249
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ZcuSWwk99q1f62vi
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "926"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:21 GMT
+      Etag:
+      - W/"6ca004cf4f42296217ffc7d260788eaa"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - bb722e97-83bc-4a5c-9a31-690dbd26f3eb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:21 GMT
+      Etag:
+      - W/"851ba9ad227c22385f39e89b4e44cbbf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - d7b40d42-8422-4b39-a1cd-1df8b979d606
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tHkfaytEDikNKan4","name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.253.33/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:21 GMT
+      Etag:
+      - W/"1f1c9f0e092adb2d241cb4972c81f881"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 9c4979c7-20d8-48f6-a75b-8840c7a7e08b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"detached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:21 GMT
+      Etag:
+      - W/"6bd67bdaa44cf3a36017891cde166663"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 03615a09-6212-4fdb-b6c7-906e47c8b5e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"detached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:21 GMT
+      Etag:
+      - W/"6bd67bdaa44cf3a36017891cde166663"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - f5d1d7bc-5820-460c-9320-4530f49abeeb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:21 GMT
+      Etag:
+      - W/"851ba9ad227c22385f39e89b4e44cbbf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 66ea38c1-c03d-4bd4-b36e-11a45d5af88c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:22 GMT
+      Etag:
+      - W/"851ba9ad227c22385f39e89b4e44cbbf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - beea1f53-e8cf-46fc-92f4-49524244a178
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:22 GMT
+      Etag:
+      - W/"851ba9ad227c22385f39e89b4e44cbbf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - a08fa4e9-315e-41cc-b453-3064e362bfe4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:22 GMT
+      Etag:
+      - W/"851ba9ad227c22385f39e89b4e44cbbf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 507b6fa2-0ab8-44e7-a71a-7911e5d43aa7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu"},"virtual_machine_package":{"permalink":"rock-1"}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/package
+    method: PUT
+  response:
+    body: '{"task":{"id":"task_SlvfqYE2cYR8YWzV","name":"Change package","status":"pending","created_at":1783600702,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "156"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:22 GMT
+      Etag:
+      - W/"2980751a9dfb3834cd2be1bcce44948b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 5bb81cd2-f04c-4036-bedb-6e86a9c0eec7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_SlvfqYE2cYR8YWzV
+    method: GET
+  response:
+    body: '{"task":{"id":"task_SlvfqYE2cYR8YWzV","name":"Change package","status":"running","created_at":1783600702,"started_at":1783600703,"finished_at":null,"progress":15}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "163"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:23 GMT
+      Etag:
+      - W/"7a2d1da9ec977b763ab654380c14763a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - ab7929b4-d049-41d1-85c0-e15f9363bf7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_SlvfqYE2cYR8YWzV
+    method: GET
+  response:
+    body: '{"task":{"id":"task_SlvfqYE2cYR8YWzV","name":"Change package","status":"completed","created_at":1783600702,"started_at":1783600703,"finished_at":1783600704,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "172"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:28 GMT
+      Etag:
+      - W/"13d0fd97e182b3d2777728ea44a0d4f4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 0ecfa959-022c-4784-a534-b371d92fbc0d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu"},"properties":{}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:28 GMT
+      Etag:
+      - W/"c52d7868f00f4d5068bcefda0c5ec4fe"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 1251ab69-3a29-47d7-9e59-bea8f324b3c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"c52d7868f00f4d5068bcefda0c5ec4fe"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 9266ff11-f3be-4a90-9e14-daabf5855915
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tHkfaytEDikNKan4","name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.253.33/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"1f1c9f0e092adb2d241cb4972c81f881"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - c3ab31f1-6be4-4f77-95c9-464a1ed5c56d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"detached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"6bd67bdaa44cf3a36017891cde166663"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - a0a863bb-b9ae-4cf2-ac8c-b8a8f3280768
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"detached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"6bd67bdaa44cf3a36017891cde166663"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - c08dde9e-6ad1-436a-93b7-a2d4df4536a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"c52d7868f00f4d5068bcefda0c5ec4fe"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - 0f68d3f4-a20d-413e-8095-e73a5f077379
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ZcuSWwk99q1f62vi
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "926"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"6ca004cf4f42296217ffc7d260788eaa"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - c8188c78-98ed-414d-9ee8-f96ce464c851
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"c52d7868f00f4d5068bcefda0c5ec4fe"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - b93a3630-473e-4a33-860a-61b8621d0ede
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tHkfaytEDikNKan4","name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.253.33/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"1f1c9f0e092adb2d241cb4972c81f881"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - f9d94ea2-e274-47d3-b621-39597f24eb0a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"detached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"6bd67bdaa44cf3a36017891cde166663"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 8a26e63f-92f4-4566-ab38-89c761ad4d36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tHkfaytEDikNKan4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tHkfaytEDikNKan4","virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb"},"name":"Public
+      Network on tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:39:ee:b5:72:65","state":"detached","ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"6bd67bdaa44cf3a36017891cde166663"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - b941dbe0-c54b-4c5b-98a7-12321562e21e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:29 GMT
+      Etag:
+      - W/"c52d7868f00f4d5068bcefda0c5ec4fe"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 2202469b-349c-4144-a5d9-9a465a5bf41d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_ONIijWkJViNGpXiD","keep_until":1783773509,"object_id":"vm_4BXkJZRBjjHKPKXu","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_4BXkJZRBjjHKPKXu","name":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb","hostname":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host","fqdn":"tf-acc-test-update-package-downgrade-stopped-f9nwpwdteezb-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"lZKRALij7GPlbRdJ","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ZcuSWwk99q1f62vi","address":"185.44.253.33","reverse_dns":"185-44-253-33.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.33/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_4BXkJZRBjjHKPKXu","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:30 GMT
+      Etag:
+      - W/"e1b54e4030a8d60b275ce87083e7e7f9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - 3c7e2a6d-a6aa-44d1-86e0-5b20f32d7529
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ZcuSWwk99q1f62vi
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:31 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - 1e7ca5c9-d66c-413c-a0d7-7b4537c1d394
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4BXkJZRBjjHKPKXu
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_tRWag2DeW1fw3Xn0","name":"Purge items from trash","status":"pending","created_at":1783600711,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:31 GMT
+      Etag:
+      - W/"915358ed6505f728ce68771b60d8443d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - 4aa2aac6-e0be-418d-9451-5e1d8a6d7982
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_ONIijWkJViNGpXiD","keep_until":1783773509,"object_id":"vm_4BXkJZRBjjHKPKXu","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:32 GMT
+      Etag:
+      - W/"f12c8def3966406fc18c92657477c539"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - d84e4f16-73f3-4ff3-b1ff-54d1761d3ebd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:37 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - 7a021def-901f-475d-a4ad-eeb6894bbbd5
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ZcuSWwk99q1f62vi
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:37 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - 9c773ad6-bf0a-467a-b5ff-d127891f1bce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:37 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - 23c6b456-72c6-4293-8ab8-cda56c38aad5
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4BXkJZRBjjHKPKXu
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:37 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 08bcece8-613d-4e79-af77-6f82de537a42
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ZcuSWwk99q1f62vi
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:37 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - d1a6b572-fa90-4f4a-8c88-a11a40d3cf4f
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_package_upgrade_stopped.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_package_upgrade_stopped.cassette.rand_id
@@ -1,0 +1,1 @@
+pkbn1rd0rcd7

--- a/internal/provider/testdata/VirtualMachine_update_package_upgrade_stopped.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_package_upgrade_stopped.cassette.yaml
@@ -1,0 +1,2599 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
+    method: GET
+  response:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "196"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - adcd6da0-9251-40c5-a5d4-cd0dd11c4674
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"185-44-252-250.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "691"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"429bda7aff60acc3f2219f9b8af07490"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - b6ea1cfc-1389-4b46-b593-eab6f3232e97
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_v5kTrZXniEOmmNAf
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"185-44-252-250.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "709"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"f0e051f8b6ac22cee457c62f7ea9eb54"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 210dea7a-663f-49e9-a775-08b8ce7f9e48
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_v5kTrZXniEOmmNAf
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"185-44-252-250.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "709"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"f0e051f8b6ac22cee457c62f7ea9eb54"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - a985db8d-72aa-4864-a164-a31f8b116035
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-1</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_v5kTrZXniEOmmNAf</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host</Hostname></Hostname><Name>tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
+    method: POST
+  response:
+    body: '{"task":{"id":"task_uYW2DXqBkbuvJNC8","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_YnJLEMWaEIH6HAxT","state":"pending"},"virtual_machine_build":{"id":"vmbuild_YnJLEMWaEIH6HAxT","state":"pending"},"hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "316"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:08 GMT
+      Etag:
+      - W/"436c80a8f35af8c41f467a44af48ba9e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - fae5f775-a174-4b9c-b65f-38949d483a23
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_YnJLEMWaEIH6HAxT
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_YnJLEMWaEIH6HAxT","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:11 GMT
+      Etag:
+      - W/"e8627df42a8057d7cd42dd40a5125997"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - a7c732a2-b0ae-4a9f-ab96-6b2d1c682ce2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_YnJLEMWaEIH6HAxT
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_YnJLEMWaEIH6HAxT","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:16 GMT
+      Etag:
+      - W/"0b3e65f8bf59db54cdcd80831d4e280d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 07c2264a-7fa1-4e0f-af45-21eb71ee7960
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_YnJLEMWaEIH6HAxT
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_YnJLEMWaEIH6HAxT","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:26 GMT
+      Etag:
+      - W/"0b3e65f8bf59db54cdcd80831d4e280d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 16d8f919-701f-41a4-8fb5-27a91e94733e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_YnJLEMWaEIH6HAxT
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_YnJLEMWaEIH6HAxT","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1783600628},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:36 GMT
+      Etag:
+      - W/"3834220ae2547c8552c08b2ffa76f5e7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 5c5108ac-20d9-436a-ba0c-c9e5ea511d14
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"starting","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:38 GMT
+      Etag:
+      - W/"71da7d4c91b153f7ceb179c225a120f0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - a2b34778-3f94-417c-8880-2992a0cfdd85
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:43 GMT
+      Etag:
+      - W/"de6efd58a1578626d4654466682cd260"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - c3227641-62f2-4239-ada6-b5ab939cd073
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:43 GMT
+      Etag:
+      - W/"de6efd58a1578626d4654466682cd260"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 442e1b14-2f1a-4d6a-bec9-ae8a8bd5adfc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_NMOwUktHZQMnQGBB","name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.250/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:43 GMT
+      Etag:
+      - W/"cdef51e6ae5f1b396cc0c00ca661ee78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 196b6497-7f53-407e-9483-4fbd48ceca2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"attached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:43 GMT
+      Etag:
+      - W/"57dc7ba71709af72180c9851af62f3b7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - a0a87bc3-f14a-457f-83ff-0bae95547fec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"attached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:43 GMT
+      Etag:
+      - W/"57dc7ba71709af72180c9851af62f3b7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 8350c5b7-aab9-4128-9a9b-e2de1a8a8749
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:43 GMT
+      Etag:
+      - W/"de6efd58a1578626d4654466682cd260"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 9fde3cc3-cae2-43c3-9e73-f8e1035576f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_v5kTrZXniEOmmNAf
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "924"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:44 GMT
+      Etag:
+      - W/"824936759388d09169fc227d2f638b0e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - d7647cff-ebd1-42ad-83cd-162bc6bdddde
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"started","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:44 GMT
+      Etag:
+      - W/"de6efd58a1578626d4654466682cd260"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 96f77bff-b347-49cb-937d-7ec8cae50718
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_NMOwUktHZQMnQGBB","name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.250/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:44 GMT
+      Etag:
+      - W/"cdef51e6ae5f1b396cc0c00ca661ee78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 9fc66d07-13df-4fe9-920a-40ba88a19e5b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"attached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:44 GMT
+      Etag:
+      - W/"57dc7ba71709af72180c9851af62f3b7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - c892f250-266b-43e8-8d63-0dddb22d93b8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"attached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:44 GMT
+      Etag:
+      - W/"57dc7ba71709af72180c9851af62f3b7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - ac80ba49-ff60-4e85-8eb0-3c3068214ca5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: POST
+  response:
+    body: '{"task":{"id":"task_hzqIMdT0C82WV9dB","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:44 GMT
+      Etag:
+      - W/"692af6e8da3c26ad30fb4d7fe9885494"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - f1b2b759-16b4-4c44-bc1b-b7e0c9034641
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_hzqIMdT0C82WV9dB
+    method: GET
+  response:
+    body: '{"task":{"id":"task_hzqIMdT0C82WV9dB","name":"Stop virtual machine","status":"running","created_at":1783600664,"started_at":1783600665,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:45 GMT
+      Etag:
+      - W/"709d8a093506a4745410658d38d6acc2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - f8bf6d99-763c-477f-91bb-fdc57274a92f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_hzqIMdT0C82WV9dB
+    method: GET
+  response:
+    body: '{"task":{"id":"task_hzqIMdT0C82WV9dB","name":"Stop virtual machine","status":"completed","created_at":1783600664,"started_at":1783600665,"finished_at":1783600668,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:50 GMT
+      Etag:
+      - W/"550049de235627a88de93ebffc927103"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - 87f0a22b-8665-47e5-918f-5d1f2f4a8c95
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"3b7bbb478b58aac3c62368edae33689d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - ee06901c-8d1b-44d8-b7ef-7802bcb2beea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_v5kTrZXniEOmmNAf
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "924"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"824936759388d09169fc227d2f638b0e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - 2a288dbb-cd85-4d37-b7e0-064872ea02c9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"3b7bbb478b58aac3c62368edae33689d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - 93df7828-a7a1-4619-ae4a-1b49181ea228
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_NMOwUktHZQMnQGBB","name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.250/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"cdef51e6ae5f1b396cc0c00ca661ee78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - e959738b-82d0-499a-b1e7-b8223173f38c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"detached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"a3fd90a314aa7b3bf713fe4161d59d27"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - 23b17fdf-610d-4ffa-8345-fd8fb08affe1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"detached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"a3fd90a314aa7b3bf713fe4161d59d27"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - 810a22f0-1d26-42ec-9fb2-7fe87e7bebac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"3b7bbb478b58aac3c62368edae33689d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - b105eb2f-1d85-49ec-8ee6-709bfcf1bab5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"3b7bbb478b58aac3c62368edae33689d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - 7650fbfd-78da-4ebf-989f-9859281d553e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"3b7bbb478b58aac3c62368edae33689d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 6e21a65c-e61e-4519-92a4-ccca55870908
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":1,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"3b7bbb478b58aac3c62368edae33689d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - 628af06d-5fb8-4ed5-bc06-8452403b8f7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE"},"virtual_machine_package":{"permalink":"rock-3"}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/package
+    method: PUT
+  response:
+    body: '{"task":{"id":"task_mfeQbKLnMakXONb0","name":"Change package","status":"pending","created_at":1783600672,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "156"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:52 GMT
+      Etag:
+      - W/"26c9ec711a3ca969739a55b0f8ae6ceb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - 707c281d-c825-4739-a55d-cf1db591771c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_mfeQbKLnMakXONb0
+    method: GET
+  response:
+    body: '{"task":{"id":"task_mfeQbKLnMakXONb0","name":"Change package","status":"running","created_at":1783600672,"started_at":1783600673,"finished_at":null,"progress":15}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "163"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:53 GMT
+      Etag:
+      - W/"b4bbe82166098a2f7a0222c3c6253a55"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 3887a620-a938-48b6-9519-dedaad98623e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_mfeQbKLnMakXONb0
+    method: GET
+  response:
+    body: '{"task":{"id":"task_mfeQbKLnMakXONb0","name":"Change package","status":"completed","created_at":1783600672,"started_at":1783600673,"finished_at":1783600675,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "172"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:58 GMT
+      Etag:
+      - W/"0d75e3a3b634d1d2466de3544b3b9c20"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "939"
+      X-Request-Id:
+      - 29cc06cb-5f8d-4bd2-9edc-f1cf01f8aef7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE"},"properties":{}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:58 GMT
+      Etag:
+      - W/"def40d741e2bc077fa247d721d7d4d7d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "938"
+      X-Request-Id:
+      - 320fc7b3-cd24-406f-907f-e69ecaf11277
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"def40d741e2bc077fa247d721d7d4d7d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "937"
+      X-Request-Id:
+      - 870435bf-6bca-48aa-b347-cef637e0eae1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_NMOwUktHZQMnQGBB","name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.250/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"cdef51e6ae5f1b396cc0c00ca661ee78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "936"
+      X-Request-Id:
+      - a5eab089-18c9-4170-b14e-801b40ebf973
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"detached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"a3fd90a314aa7b3bf713fe4161d59d27"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "935"
+      X-Request-Id:
+      - 00e9accb-76dd-470d-be34-b755a5d13861
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"detached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"a3fd90a314aa7b3bf713fe4161d59d27"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "934"
+      X-Request-Id:
+      - 1589d853-8b5a-4006-90f9-66075c9240f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"def40d741e2bc077fa247d721d7d4d7d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "933"
+      X-Request-Id:
+      - c52b420e-f694-4721-9d83-c7622543ecfb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_v5kTrZXniEOmmNAf
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "924"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"824936759388d09169fc227d2f638b0e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "932"
+      X-Request-Id:
+      - d4c2c30d-8ebc-4551-a633-3c5e6fea4dba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"def40d741e2bc077fa247d721d7d4d7d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "931"
+      X-Request-Id:
+      - f636cdd3-65f9-4435-8317-f6edf2520eea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_NMOwUktHZQMnQGBB","name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.44.252.250/22"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"cdef51e6ae5f1b396cc0c00ca661ee78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "930"
+      X-Request-Id:
+      - f6953001-23be-400c-8923-14f54ce034ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"detached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"a3fd90a314aa7b3bf713fe4161d59d27"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "929"
+      X-Request-Id:
+      - 90b9b1a4-4e21-4260-bdb1-9b4359414163
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_NMOwUktHZQMnQGBB
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_NMOwUktHZQMnQGBB","virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7"},"name":"Public
+      Network on tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:40:a8:ac:10:e3","state":"detached","ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "559"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"a3fd90a314aa7b3bf713fe4161d59d27"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "928"
+      X-Request-Id:
+      - 429dfd16-e84e-49c8-a168-457d7f623791
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:37:59 GMT
+      Etag:
+      - W/"def40d741e2bc077fa247d721d7d4d7d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "927"
+      X-Request-Id:
+      - e524cfbc-4d01-4258-9544-000572ce1db0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_LRDDDKvvD0d10ycb","keep_until":1783773479,"object_id":"vm_nLzXZPHE2c8SCDmE","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_nLzXZPHE2c8SCDmE","name":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7","hostname":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host","fqdn":"tf-acc-test-update-package-upgrade-stopped-pkbn1rd0rcd7-host.terraform-acc-test.katapult.cloud","description":null,"created_at":1783600634,"initial_root_password":"c7mjJA0ApvJmXoBK","state":"stopped","suspended":false,"suspended_at":null,"zone":{"id":"zone_KdXXMdv8zRMZXc7q","name":"LON-3","permalink":"lon-zone-3","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_v5kTrZXniEOmmNAf","address":"185.44.252.250","reverse_dns":"185-44-252-250.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_9FYjp2bT20hooq9u","address":"185.44.252.0","gateway":"185.44.255.254","mask":22,"billable":true,"version":4},"allocation_id":"vm_nLzXZPHE2c8SCDmE","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:00 GMT
+      Etag:
+      - W/"be3c2fd55e9cc92ec994fdcac1f17c85"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "926"
+      X-Request-Id:
+      - 404951c8-eb8b-4a05-a94a-f393b46e38e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_v5kTrZXniEOmmNAf
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:00 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 0f06fd28-b7e5-495b-a349-bc015592960d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_nLzXZPHE2c8SCDmE
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_aULDQrBR6Ye970lM","name":"Purge items from trash","status":"pending","created_at":1783600680,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:00 GMT
+      Etag:
+      - W/"f343bb963d52d4e4e4227d3ee7e08051"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 88397987-bbae-4044-919f-6993bd47f080
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_LRDDDKvvD0d10ycb","keep_until":1783773479,"object_id":"vm_nLzXZPHE2c8SCDmE","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:01 GMT
+      Etag:
+      - W/"e52e9912c6f1cc75016ef6d57e01bcef"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 1856aedf-ef21-45f2-a3ab-44775d4c23c8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 167ab583-4b62-44cb-b699-f36de223fc51
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_v5kTrZXniEOmmNAf
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:07 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - e87d37f1-7921-438a-a7f6-f55bdf961354
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - bb228442-ee72-43ef-90a7-15863729c06b
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_nLzXZPHE2c8SCDmE
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 8c722d96-633a-485b-bea9-0ad7f22852a1
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_v5kTrZXniEOmmNAf
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Jul 2026 12:38:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - b71290a5-68bd-4aff-a2c7-1242793bf72b
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
Follow-up to #177, from review of that branch.

## Why

Two issues with the package-change flow as it stands on the base branch:

1. The running-VM downgrade validation ran inside the update handler,
   after other changes in the same apply (IP allocations, virtual
   networks, speed profile) had already mutated the VM. A rejected
   downgrade therefore failed the apply halfway through, leaving a
   partial apply behind. The check now lives in `CustomizeDiff`, so a
   downgrade against a running VM fails at plan time before anything
   is touched.

2. The API rejects a `ChangePackage` call targeting the VM's current
   package. Switching the configured value between the ID and permalink
   of the same package (e.g. after `terraform import`) produced a diff
   whose apply would always error. The update handler now detects this
   and skips the API call, letting the post-update read rewrite state in
   the configured format.

## What

- Move downgrade validation into `CustomizeDiff`
  (`validateVirtualMachinePackageChange`), keeping the same error
  message. It no-ops for new resources, unknown values, missing/trashed
  VMs, stopped VMs, and same-package format switches.
- Skip `ChangePackage` in the update handler when the new value
  references the current package by ID or permalink.
- Replace the `"started"` string literal with
  `core.VirtualMachineStarted`, and extract ref-building into a
  `virtualMachinePackageRef` helper.
- Add unit tests for `normalizeVirtualMachinePackageForState` and
  `virtualMachinePackageRef`.
- Re-record the three package-change cassettes: go-vcr v1 replays
  interactions in recorded order, and moving the validation to plan
  time changes when (and how often) the VM and package lookups happen.

## Testing

- All three package-change acceptance tests pass in VCR replay against
  the re-recorded cassettes.
- New unit tests pass; `go build` and `gofmt` clean.

## Stopped-VM coverage

Also adds acceptance tests for package changes against stopped VMs
(downgrade and upgrade), using a `PreConfig` hook that stops the VM
out-of-band via the API between steps. With these, the matrix is:
upgrade running (permalink and ID), upgrade stopped, downgrade stopped,
and downgrade-while-running error.
