### PR TITLE
test: speed up VCR replay acceptance tests

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -88,8 +88,9 @@ func waitForTrashObjectNotFound(
 			return nil, "exists", nil
 		},
 		Timeout:                   timeout,
-		Delay:                     1 * time.Second,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(1 * time.Second),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 
@@ -124,8 +125,9 @@ func waitForTaskCompletion(
 			return t, string(t.Status), nil
 		},
 		Timeout:                   timeout,
-		Delay:                     1 * time.Second,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(1 * time.Second),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"time"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/krystal/go-katapult"
 	"github.com/krystal/go-katapult/core"
@@ -16,6 +18,7 @@ type Meta struct {
 
 	GeneratedNamePrefix  string
 	SkipTrashObjectPurge bool
+	testMode             bool
 
 	// Raw provider attribute string values
 	confAPIKey       string
@@ -25,6 +28,25 @@ type Meta struct {
 	// Internal cache of shallow lookup reference objects
 	DataCenterRef   core.DataCenterRef
 	OrganizationRef core.OrganizationRef
+}
+
+// stateChangeDelay returns zero in replay mode, or d otherwise.
+func (m *Meta) stateChangeDelay(d time.Duration) time.Duration {
+	if m.testMode {
+		return 0
+	}
+
+	return d
+}
+
+// stateChangePollInterval returns a short fixed interval in replay mode so
+// StateChangeConf does not use its production exponential backoff.
+func (m *Meta) stateChangePollInterval() time.Duration {
+	if m.testMode {
+		return time.Millisecond
+	}
+
+	return 0
 }
 
 func (m *Meta) UseOrGenerateName(name string) string {

--- a/internal/provider/meta_test.go
+++ b/internal/provider/meta_test.go
@@ -3,9 +3,22 @@ package provider
 import (
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMeta_StateChangeTiming(t *testing.T) {
+	delay := 5 * time.Second
+
+	productionMeta := &Meta{}
+	assert.Equal(t, delay, productionMeta.stateChangeDelay(delay))
+	assert.Zero(t, productionMeta.stateChangePollInterval())
+
+	replayMeta := &Meta{testMode: true}
+	assert.Zero(t, replayMeta.stateChangeDelay(delay))
+	assert.Equal(t, time.Millisecond, replayMeta.stateChangePollInterval())
+}
 
 func TestMeta_UseOrGenerateName(t *testing.T) {
 	type fields struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -32,6 +32,7 @@ type Config struct {
 	HTTPClient *http.Client
 
 	GeneratedNamePrefix string
+	TestMode            bool
 }
 
 func New(c *Config) func() *schema.Provider { //nolint:funlen
@@ -235,6 +236,7 @@ func configure(
 				"KATAPULT_SKIP_TRASH_OBJECT_PURGE",
 			),
 			GeneratedNamePrefix: conf.GeneratedNamePrefix,
+			testMode:            conf.TestMode,
 		}
 
 		if m.GeneratedNamePrefix == "" {
@@ -273,6 +275,11 @@ func configure(
 		}
 
 		rhc := newRetryableHTTPClient(httpClient, m.Logger)
+		if conf.TestMode {
+			rhc.RetryMax = 0
+			rhc.RetryWaitMin = 0
+			rhc.RetryWaitMax = 0
+		}
 		c.HTTPClient = rhc.StandardClient()
 
 		m.Client = c

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -73,6 +73,9 @@ func providerFactories(
 
 	if r != nil {
 		conf.HTTPClient = &http.Client{Transport: r}
+		if r.Mode() == recorder.ModeReplaying {
+			conf.TestMode = true
+		}
 	}
 
 	return providerFactoryList{

--- a/internal/provider/resource_file_storage_volume.go
+++ b/internal/provider/resource_file_storage_volume.go
@@ -306,8 +306,9 @@ func waitForFileStorageVolumeToBeReady(
 			return f, string(f.State), nil
 		},
 		Timeout:                   timeout,
-		Delay:                     delay,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(delay),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 

--- a/internal/provider/resource_file_storage_volume_test.go
+++ b/internal/provider/resource_file_storage_volume_test.go
@@ -81,8 +81,9 @@ func testSweepFileStorageVolumes(_ string) error {
 				return nil, "exists", nil
 			},
 			Timeout:                   5 * time.Minute,
-			Delay:                     2 * time.Second,
-			MinTimeout:                5 * time.Second,
+			Delay:                     m.stateChangeDelay(2 * time.Second),
+			MinTimeout:                m.stateChangeDelay(5 * time.Second),
+			PollInterval:              m.stateChangePollInterval(),
 			ContinuousTargetOccurence: 1,
 		}
 

--- a/internal/provider/resource_virtual_machine.go
+++ b/internal/provider/resource_virtual_machine.go
@@ -493,8 +493,9 @@ func resourceVirtualMachineCreate(
 			return b.VirtualMachine, string(b.State), nil
 		},
 		Timeout:                   d.Timeout(schema.TimeoutCreate),
-		Delay:                     2 * time.Second,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(2 * time.Second),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 
@@ -546,8 +547,9 @@ func resourceVirtualMachineCreate(
 			return v, string(v.State), nil
 		},
 		Timeout:                   d.Timeout(schema.TimeoutCreate),
-		Delay:                     2 * time.Second,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(2 * time.Second),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 
@@ -1072,8 +1074,9 @@ func waitForVirtualMachineToStop(
 			return vm, string(vm.State), nil
 		},
 		Timeout:                   timeout,
-		Delay:                     1 * time.Second,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(1 * time.Second),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 

--- a/internal/provider/resource_virtual_machine_test.go
+++ b/internal/provider/resource_virtual_machine_test.go
@@ -95,8 +95,9 @@ func testSweepVirtualMachines(_ string) error {
 					return v, string(v.State), nil
 				},
 				Timeout:                   5 * time.Minute,
-				Delay:                     2 * time.Second,
-				MinTimeout:                5 * time.Second,
+				Delay:                     m.stateChangeDelay(2 * time.Second),
+				MinTimeout:                m.stateChangeDelay(5 * time.Second),
+				PollInterval:              m.stateChangePollInterval(),
 				ContinuousTargetOccurence: 1,
 			}
 
@@ -135,8 +136,9 @@ func testSweepVirtualMachines(_ string) error {
 				return nil, "exists", nil
 			},
 			Timeout:                   5 * time.Minute,
-			Delay:                     2 * time.Second,
-			MinTimeout:                5 * time.Second,
+			Delay:                     m.stateChangeDelay(2 * time.Second),
+			MinTimeout:                m.stateChangeDelay(5 * time.Second),
+			PollInterval:              m.stateChangePollInterval(),
 			ContinuousTargetOccurence: 1,
 		}
 

--- a/internal/v6provider/helpers.go
+++ b/internal/v6provider/helpers.go
@@ -69,8 +69,9 @@ func waitForTrashObjectNotFound(
 			return nil, "exists", nil
 		},
 		Timeout:                   timeout,
-		Delay:                     1 * time.Second,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(1 * time.Second),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 

--- a/internal/v6provider/meta.go
+++ b/internal/v6provider/meta.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/krystal/go-katapult"
 	core "github.com/krystal/go-katapult/next/core"
@@ -15,17 +17,38 @@ import (
 )
 
 type Meta struct {
-	Client *katapult.Client
-	Core   core.ClientWithResponsesInterface
-	Logger hclog.Logger
+	Client      *katapult.Client
+	Core        core.ClientWithResponsesInterface
+	Logger      hclog.Logger
+	retryClient *retryablehttp.Client
 
 	GeneratedNamePrefix  string
 	SkipTrashObjectPurge bool
+	testMode             bool
 
 	// Raw provider attribute string values
 	confAPIKey       string
 	confDataCenter   string
 	confOrganization string
+}
+
+// stateChangeDelay returns zero in replay mode, or d otherwise.
+func (m *Meta) stateChangeDelay(d time.Duration) time.Duration {
+	if m.testMode {
+		return 0
+	}
+
+	return d
+}
+
+// stateChangePollInterval returns a short fixed interval in replay mode so
+// StateChangeConf does not use its production exponential backoff.
+func (m *Meta) stateChangePollInterval() time.Duration {
+	if m.testMode {
+		return time.Millisecond
+	}
+
+	return 0
 }
 
 func (m *Meta) UseOrGenerateName(name string) string {
@@ -117,6 +140,7 @@ func NewMeta(
 	}
 
 	rhc := newRetryableHTTPClient(httpClient, m.Logger)
+	m.retryClient = rhc
 
 	coreClient, err := core.NewClientWithResponses(
 		serverURL.String(),

--- a/internal/v6provider/meta_test.go
+++ b/internal/v6provider/meta_test.go
@@ -3,9 +3,22 @@ package v6provider
 import (
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMeta_StateChangeTiming(t *testing.T) {
+	delay := 5 * time.Second
+
+	productionMeta := &Meta{}
+	assert.Equal(t, delay, productionMeta.stateChangeDelay(delay))
+	assert.Zero(t, productionMeta.stateChangePollInterval())
+
+	replayMeta := &Meta{testMode: true}
+	assert.Zero(t, replayMeta.stateChangeDelay(delay))
+	assert.Equal(t, time.Millisecond, replayMeta.stateChangePollInterval())
+}
 
 func TestMeta_UseOrGenerateName(t *testing.T) {
 	type fields struct {

--- a/internal/v6provider/resource_file_storage_volume.go
+++ b/internal/v6provider/resource_file_storage_volume.go
@@ -517,8 +517,9 @@ func waitForFileStorageVolumeToBeReady(
 			return f, string(*f.State), nil
 		},
 		Timeout:                   timeout,
-		Delay:                     delay,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(delay),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 

--- a/internal/v6provider/resource_file_storage_volume_test.go
+++ b/internal/v6provider/resource_file_storage_volume_test.go
@@ -94,8 +94,9 @@ func testSweepFileStorageVolumes(_ string) error {
 				return nil, "exists", nil
 			},
 			Timeout:                   5 * time.Minute,
-			Delay:                     2 * time.Second,
-			MinTimeout:                5 * time.Second,
+			Delay:                     m.stateChangeDelay(2 * time.Second),
+			MinTimeout:                m.stateChangeDelay(5 * time.Second),
+			PollInterval:              m.stateChangePollInterval(),
 			ContinuousTargetOccurence: 1,
 		}
 

--- a/internal/v6provider/resource_virtual_machine_test.go
+++ b/internal/v6provider/resource_virtual_machine_test.go
@@ -106,8 +106,9 @@ func testSweepVirtualMachines(_ string) error {
 						nil
 				},
 				Timeout:                   5 * time.Minute,
-				Delay:                     2 * time.Second,
-				MinTimeout:                5 * time.Second,
+				Delay:                     m.stateChangeDelay(2 * time.Second),
+				MinTimeout:                m.stateChangeDelay(5 * time.Second),
+				PollInterval:              m.stateChangePollInterval(),
 				ContinuousTargetOccurence: 1,
 			}
 
@@ -161,8 +162,9 @@ func testSweepVirtualMachines(_ string) error {
 				return nil, "exists", nil
 			},
 			Timeout:                   5 * time.Minute,
-			Delay:                     2 * time.Second,
-			MinTimeout:                5 * time.Second,
+			Delay:                     m.stateChangeDelay(2 * time.Second),
+			MinTimeout:                m.stateChangeDelay(5 * time.Second),
+			PollInterval:              m.stateChangePollInterval(),
 			ContinuousTargetOccurence: 1,
 		}
 

--- a/internal/v6provider/v6provider_test.go
+++ b/internal/v6provider/v6provider_test.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/dnaeon/go-vcr/cassette"
@@ -108,24 +108,23 @@ func newTestTools(t *testing.T) *testTools {
 		testAccResourceNamePrefix, v6config.HTTPClient, "", "")
 	require.NoError(t, err)
 
+	if r != nil && r.Mode() == recorder.ModeReplaying {
+		meta.testMode = true
+		meta.retryClient.RetryMax = 0
+		meta.retryClient.RetryWaitMin = 0
+		meta.retryClient.RetryWaitMax = 0
+		v5Config.TestMode = true
+	}
+
 	v6config.m = meta
 
-	upgradedSDKServer, err := tf5to6server.UpgradeServer(
-		ctx, v5provider.New(v5Config)().GRPCProvider,
+	// UpgradeServer and NewMuxServer inspect each provider's schema. Defer that
+	// work until the factory runs so parallel tests do not serialize in setup.
+	var (
+		muxOnce     sync.Once
+		muxedServer tfprotov6.ProviderServer
+		muxErr      error
 	)
-	if err != nil {
-		require.NoError(t, err)
-	}
-
-	providers := []func() tfprotov6.ProviderServer{
-		func() tfprotov6.ProviderServer { return upgradedSDKServer },
-		providerserver.NewProtocol6(New(v6config)()),
-	}
-
-	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	return &testTools{
 		T:        t,
@@ -133,9 +132,37 @@ func newTestTools(t *testing.T) *testTools {
 		Recorder: r,
 		Meta:     meta,
 		ProviderFactories: providerFactoryList{
-			//nolint:unparam // must return an error to match the map signature
 			"katapult": func() (tfprotov6.ProviderServer, error) {
-				return muxServer.ProviderServer(), nil
+				muxOnce.Do(func() {
+					upgradedSDKServer, upgradeErr := tf5to6server.UpgradeServer(
+						ctx, v5provider.New(v5Config)().GRPCProvider,
+					)
+					if upgradeErr != nil {
+						muxErr = upgradeErr
+
+						return
+					}
+
+					providers := []func() tfprotov6.ProviderServer{
+						func() tfprotov6.ProviderServer {
+							return upgradedSDKServer
+						},
+						providerserver.NewProtocol6(New(v6config)()),
+					}
+
+					muxServer, newMuxErr := tf6muxserver.NewMuxServer(
+						ctx, providers...,
+					)
+					if newMuxErr != nil {
+						muxErr = newMuxErr
+
+						return
+					}
+
+					muxedServer = muxServer.ProviderServer()
+				})
+
+				return muxedServer, muxErr
 			},
 		},
 	}


### PR DESCRIPTION
PR #172 contains useful VCR replay optimizations, but targets the
`migrate-vm-to-v6` branch. This ports the applicable changes directly to
`main` so current acceptance-test CI can benefit without waiting for that
migration.

## Summary

- bypass normal state-change delays and HTTP retry backoff only during VCR
  replay, preserving production behavior
- apply fast fixed polling to every applicable v5 and v6 waiter currently on
  `main`, including test sweepers
- lazily initialize and reuse the protocol v6 mux server to reduce parallel test
  setup contention
- add coverage for production and replay-mode timing behavior

## Testing

- `make lint`
- full VCR replay acceptance suite passed across both provider packages
- representative file-storage-volume replay improved from 36.24s to 3.00s
