### PR TITLE
chore: gate CodeRabbit reviews by label

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,8 @@ inheritance: true
 reviews:
   review_status: true
   auto_review:
-    enabled: true
+    enabled: false
+    labels:
+      - "coderabbit:review"
   path_filters:
     - "!**/testdata/**/*.cassette.*"


### PR DESCRIPTION
## Summary

CodeRabbit currently reviews every pull request automatically. Align its behavior with Aker's label-gated setup so reviews happen only when they are explicitly requested.

- disable unconditional automatic reviews
- opt pull requests in with the `coderabbit:review` label
- preserve the existing VCR cassette path filter

## Testing

- parsed `.coderabbit.yaml` with Ruby's safe YAML loader
- verified the diff with `git diff --check`
