### PR TITLE
chore: centralize development tooling in mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
-          install_args: go
+          install_args: >-
+            go
+            go:github.com/bflad/tfproviderlint/cmd/tfproviderlint
       - name: Run tfproviderlint
         run: mise run --skip-tools lint:provider
 
@@ -115,7 +117,9 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
-          install_args: go terraform
+          install_args: >-
+            go terraform
+            go:github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
       - name: Validate documentation
         run: mise run --skip-tools docs:verify
 

--- a/.treeboot.toml
+++ b/.treeboot.toml
@@ -1,3 +1,4 @@
 #:schema https://github.com/jimeh/treeboot/releases/latest/download/config.schema.json
 
 copy = [".envrc", "mise.local.toml", ".mise.local.toml"]
+commands = ["mise run setup"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ the legacy Terraform Plugin SDK and the Terraform Plugin Framework.
   and data sources.
 - `internal/*/testdata` contains VCR cassettes and their stable random IDs.
 - `docs` is generated provider documentation. Change provider schemas or
-  templates, then run `make docs`; do not hand-edit generated output.
+  templates, then run `mise run docs:generate`; do not hand-edit generated
+  output.
 - `CONTRIBUTING.md` documents the intentionally gradual v5-to-v6 migration and
   the ownership rules between both implementations.
 
@@ -22,11 +23,29 @@ provider package owns a change. New types belong in `internal/v6provider`.
 When migrating an existing type, remove its legacy registration in the same
 change so the mux never sees duplicate type names.
 
+## Code Exploration
+
+Use CodeGraph for structural exploration before reading broad areas of the
+codebase manually. When the CodeGraph MCP server is available, prefer its tools
+over invoking the CLI directly; use the CLI forms below as fallbacks:
+
+- Use the `codegraph_explore` MCP tool, or `codegraph explore <topic>`, to find
+  the relevant symbols, source, and call paths for a feature or behavior.
+- Use the `codegraph_node` MCP tool, or `codegraph node <symbol-or-path>`, to
+  inspect a symbol or file with its callers, callees, and dependents. Use the
+  related MCP tools, or `codegraph callers`, `codegraph callees`, and
+  `codegraph impact`, for narrower relationship queries.
+- Run `mise run codegraph:init` to initialize a missing index or sync an
+  existing one. Continue to use `rg` for exact text, filenames, and config
+  searches.
+
 ## Setup
 
 - Run `mise run treeboot` in a new worktree to copy supported local config from
-  the root checkout.
-- Run `mise run setup` to install locked tools and the Lefthook Git hooks.
+  the root checkout, then run the full project setup.
+- Run `mise run setup` to download Go dependencies, install the Lefthook Git
+  hooks, and initialize or sync CodeGraph. Mise installs missing task tools
+  automatically.
 - Keep credentials and developer overrides in ignored `.envrc`,
   `mise.local.toml`, or `.mise.local.toml` files. Never print or commit them.
 

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,6 @@ endef
 
 $(eval $(call tool,golangci-lint,github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2))
 $(eval $(call tool,gomod,github.com/Helcaraxan/gomod@v0.7.1))
-$(eval $(call tool,tfplugindocs,github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.20.0))
-$(eval $(call tool,tfproviderlint,github.com/bflad/tfproviderlint/cmd/tfproviderlint@v0.31.0))
 
 .PHONY: tools
 tools: $(TOOLS)
@@ -145,14 +143,9 @@ test-deps:
 lint: $(TOOLDIR)/golangci-lint
 	golangci-lint $(V) run
 
-.PHONY: lint-provider
-lint-provider: $(TOOLDIR)/tfproviderlint
-	tfproviderlint ./...
-
 .PHONY: format
 format: $(TOOLDIR)/golangci-lint
 	golangci-lint $(V) run --fix
-
 
 sweep:
 	$(info WARNING: This will destroy infrastructure. Use only on \
@@ -179,31 +172,6 @@ DOCKER_DEV_BUILD_CMD = docker build -f Dockerfile.dev .
 .PHONY: docker-dev-build
 docker-dev-build:
 	$(DOCKER_DEV_BUILD_CMD)
-
-#
-# Documentation
-#
-
-# Force set provider configuration environment variables, as required vars get
-# listed as "Optional" if the corresponding var is not empty.
-.PHONY: docs
-docs: $(TOOLDIR)/tfplugindocs
-	KATAPULT_API_KEY="" KATAPULT_ORGANIZATION="" KATAPULT_DATA_CENTER="" \
-		tfplugindocs generate --provider-name "terraform-provider-$(NAME)"
-
-.PHONY: check-docs
-check-docs: $(TOOLDIR)/tfplugindocs
-		tfplugindocs validate --provider-name "terraform-provider-$(NAME)"
-
-.PHONY: check-docs-generated
-check-docs-generated: $(TOOLDIR)/tfplugindocs
-	@tmpdir="$$(mktemp -d "$(CURDIR)/../.tfplugindocs-check.XXXXXX")"; \
-	trap 'rm -rf "$$tmpdir"' EXIT; \
-	KATAPULT_API_KEY="" KATAPULT_ORGANIZATION="" KATAPULT_DATA_CENTER="" \
-		tfplugindocs generate \
-		--provider-name "terraform-provider-$(NAME)" \
-		--rendered-website-dir "../$$(basename "$$tmpdir")"; \
-	diff -rN docs "$$tmpdir"
 
 #
 # Coverage

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ mise run build
 
 ### Requirements
 
+- [mise](https://mise.jdx.dev/) for development tool management and task
+  execution.
 - [Go](https://go.dev/dl/) 1.26 or later.
 - [Terraform](https://www.terraform.io/downloads.html) 1.9 or later.
 
@@ -96,6 +98,8 @@ Run `mise tasks` to discover the supported task surface. The most useful entry
 points are:
 
 - `mise run build` — build the provider binary.
+- `mise run lint:provider` — run Terraform provider-specific lint checks.
+- `mise run docs:generate` — regenerate documentation in `docs`.
 - `mise run test` — run race-enabled unit tests using VCR replay.
 - `mise run test:acceptance` — run acceptance tests using VCR replay.
 - `mise run check` — run the fast local formatting, linting, unit-test,
@@ -120,7 +124,6 @@ development container.
   environment variable to `rec` to record requests, or `off` to disable the VCR
   request recording/playback all together.
 - `make lint` — Run golangci-lint to lint all Go code.
-- `make docs` — Re-generate docs into `./docs` folder.
 
 ## Releasing the Provider
 

--- a/mise.lock
+++ b/mise.lock
@@ -46,6 +46,53 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924919"
 provenance = "github-attestations"
 
+[[tools."github:colbymchenry/codegraph"]]
+version = "1.5.0"
+backend = "github:colbymchenry/codegraph"
+
+[tools."github:colbymchenry/codegraph"."platforms.linux-arm64"]
+checksum = "sha256:9f17750aedf45d51f68caae39ed21d6e2a7290b2326e5c53f95a165918ebd1d8"
+url = "https://github.com/colbymchenry/codegraph/releases/download/v1.5.0/codegraph-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/colbymchenry/codegraph/releases/assets/485052592"
+provenance = "github-attestations"
+
+[tools."github:colbymchenry/codegraph"."platforms.linux-arm64-musl"]
+checksum = "sha256:9f17750aedf45d51f68caae39ed21d6e2a7290b2326e5c53f95a165918ebd1d8"
+url = "https://github.com/colbymchenry/codegraph/releases/download/v1.5.0/codegraph-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/colbymchenry/codegraph/releases/assets/485052592"
+provenance = "github-attestations"
+
+[tools."github:colbymchenry/codegraph"."platforms.linux-x64"]
+checksum = "sha256:2ba65e87a1210b706bb1e67d5e48b5fc4a1935e43dbb3fb5f31c5597840d2e58"
+url = "https://github.com/colbymchenry/codegraph/releases/download/v1.5.0/codegraph-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/colbymchenry/codegraph/releases/assets/485052596"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools."github:colbymchenry/codegraph"."platforms.linux-x64-musl"]
+checksum = "sha256:2ba65e87a1210b706bb1e67d5e48b5fc4a1935e43dbb3fb5f31c5597840d2e58"
+url = "https://github.com/colbymchenry/codegraph/releases/download/v1.5.0/codegraph-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/colbymchenry/codegraph/releases/assets/485052596"
+provenance = "github-attestations"
+
+[tools."github:colbymchenry/codegraph"."platforms.macos-arm64"]
+checksum = "sha256:cf5ee435a6e44d097b2f98f2b7b8b9422bb1094844404efed82519c5da1af2cf"
+url = "https://github.com/colbymchenry/codegraph/releases/download/v1.5.0/codegraph-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/colbymchenry/codegraph/releases/assets/485052595"
+provenance = "github-attestations"
+
+[tools."github:colbymchenry/codegraph"."platforms.macos-x64"]
+checksum = "sha256:0a0ccc29bf7da9d10be1458d89d7e15c55927ae24cd95e9fa3de4bdfea059dde"
+url = "https://github.com/colbymchenry/codegraph/releases/download/v1.5.0/codegraph-darwin-x64.tar.gz"
+url_api = "https://api.github.com/repos/colbymchenry/codegraph/releases/assets/485052593"
+provenance = "github-attestations"
+
+[tools."github:colbymchenry/codegraph"."platforms.windows-x64"]
+checksum = "sha256:d6798622b4f44ee6757c94335f437ee27a9ff7d3537b554cb6a2b3baf11bc4a1"
+url = "https://github.com/colbymchenry/codegraph/releases/download/v1.5.0/codegraph-win32-x64.zip"
+url_api = "https://api.github.com/repos/colbymchenry/codegraph/releases/assets/485052628"
+provenance = "github-attestations"
+
 [[tools."github:jimeh/treeboot"]]
 version = "0.13.0"
 backend = "github:jimeh/treeboot"
@@ -124,6 +171,14 @@ url = "https://dl.google.com/go/go1.26.5.darwin-amd64.tar.gz"
 [tools.go."platforms.windows-x64"]
 checksum = "sha256:97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
 url = "https://dl.google.com/go/go1.26.5.windows-amd64.zip"
+
+[[tools."go:github.com/bflad/tfproviderlint/cmd/tfproviderlint"]]
+version = "0.31.0"
+backend = "go:github.com/bflad/tfproviderlint/cmd/tfproviderlint"
+
+[[tools."go:github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"]]
+version = "0.20.0"
+backend = "go:github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
 
 [[tools."go:golang.org/x/tools/cmd/goimports"]]
 version = "0.48.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,16 @@
 #:schema https://mise.jdx.dev/schema/mise.json
+#
+# Settings
+#
 
 [settings]
 lockfile = true
 minimum_release_age = "3d"
 task.run_auto_install = true
+
+#
+# Tools
+#
 
 [tools]
 actionlint = "1"
@@ -15,24 +22,55 @@ pinact = "4"
 taplo = "0"
 terraform = "1.10"
 zizmor = "1"
+"github:colbymchenry/codegraph" = "1"
 "github:jimeh/treeboot" = "0"
+"go:github.com/bflad/tfproviderlint/cmd/tfproviderlint" = "0.31.0"
+"go:github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs" = "0.20.0"
 "go:golang.org/x/tools/cmd/goimports" = "0"
+
+#
+# Environment
+#
 
 [env]
 # DO NOT put local environment variables here. Use mise.local.toml instead.
 # Refer to mise.local.toml.example for an example.
 
+#
+# Tasks
+#
+
+# Setup and bootstrap
+
 [tasks.setup]
-description = "Install locked tools and local Git hooks"
-run = ["mise install --locked", "lefthook install"]
+description = "Set up project dependencies and development tooling"
+depends = ["codegraph:init", "deps:download", "hooks:install"]
 
 [tasks.treeboot]
 description = "Bootstrap the current worktree with Treeboot"
 run = "treeboot run"
 
+[tasks."codegraph:init"]
+description = "Initialize or sync the CodeGraph index"
+run = '''
+if [ -d .codegraph ]; then
+  codegraph sync
+else
+  codegraph init
+fi
+'''
+
+[tasks."hooks:install"]
+description = "Install local Git hooks"
+run = "lefthook install"
+
+# Build
+
 [tasks.build]
 description = "Build the provider"
 run = "make build"
+
+# Formatting
 
 [tasks.format]
 description = "Format Go and TOML files"
@@ -60,17 +98,35 @@ taplo fmt --check mise.toml mise.lock
 git diff --check
 '''
 
+# Dependencies
+
+[tasks."deps:download"]
+description = "Download Go module dependencies"
+run = "go mod download"
+
+[tasks."deps:tidy"]
+description = "Check that Go module files are tidy"
+run = "make check-tidy"
+
+[tasks."deps:verify"]
+description = "Verify downloaded Go module hashes"
+run = "make verify-deps"
+
+# Linting
+
 [tasks."lint:go"]
 description = "Lint Go code"
 run = "make lint"
 
 [tasks."lint:provider"]
 description = "Run Terraform provider-specific lint checks"
-run = "make lint-provider"
+run = "tfproviderlint ./..."
 
 [tasks.lint]
 description = "Run all lint checks"
 depends = ["lint:go", "lint:provider"]
+
+# Testing
 
 [tasks.test]
 description = "Run race-enabled unit tests with VCR replay"
@@ -80,33 +136,46 @@ run = "VCR=replay make test"
 description = "Run acceptance tests with VCR replay"
 run = "VCR=replay make testacc"
 
-[tasks."deps:verify"]
-description = "Verify downloaded Go module hashes"
-run = "make verify-deps"
-
-[tasks."deps:tidy"]
-description = "Check that Go module files are tidy"
-run = "make check-tidy"
+# Documentation
 
 [tasks."docs:generate"]
 description = "Generate provider documentation"
-run = "make docs"
+run = '''
+KATAPULT_API_KEY="" \
+KATAPULT_ORGANIZATION="" \
+KATAPULT_DATA_CENTER="" \
+tfplugindocs generate --provider-name terraform-provider-katapult
+'''
 
 [tasks."docs:check"]
 description = "Validate provider documentation"
-run = "make check-docs"
+run = "tfplugindocs validate --provider-name terraform-provider-katapult"
 
 [tasks."docs:generated"]
 description = "Check that generated provider documentation is current"
-run = "make check-docs-generated"
+run = '''
+docs_check_dir="$(mktemp -d "$PWD/../.tfplugindocs-check.XXXXXX")"
+trap 'rm -rf "$docs_check_dir"' EXIT
+KATAPULT_API_KEY="" \
+KATAPULT_ORGANIZATION="" \
+KATAPULT_DATA_CENTER="" \
+tfplugindocs generate \
+  --provider-name terraform-provider-katapult \
+  --rendered-website-dir "../$(basename "$docs_check_dir")"
+diff -rN docs "$docs_check_dir"
+'''
 
 [tasks."docs:verify"]
 description = "Validate provider documentation and generated output"
 depends = ["docs:check", "docs:generated"]
 
+# Release
+
 [tasks."release:check"]
 description = "Validate the GoReleaser configuration"
 run = "goreleaser check"
+
+# Workflows
 
 [tasks."workflows:actionlint"]
 description = "Lint GitHub Actions workflows"
@@ -135,6 +204,8 @@ depends = [
   "workflows:pinact-offline",
   "workflows:zizmor",
 ]
+
+# Validation
 
 [tasks.check]
 description = "Run fast local validation"


### PR DESCRIPTION
Development setup was split between mise, Treeboot, and Makefile-managed tools, making fresh-worktree bootstrap and tooling ownership harder to follow.

- add CodeGraph as a locked mise tool and initialize or sync its index through the parallel setup task
- have Treeboot invoke the complete project setup after copying local configuration
- move provider linting and Terraform documentation tooling from Make into versioned mise tasks, including CI installation
- reorganize the mise task surface and document the setup and CodeGraph exploration workflows

## Testing

- `mise run verify`
- `mise run treeboot`
- `treeboot check`
