### PR TITLE
feat(virtual-machine): manage power state

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -5,6 +5,7 @@ subcategory: "Compute"
 description: |-
   Manages a Virtual Machine in Katapult.
   ~> Warning: Deleting a virtual machine resource will by default purge the VM from Katapult's trash, permanently deleting it. Set skip_trash_object_purge on the provider to keep it in the trash instead.
+  Set powered_on explicitly to opt into ongoing power-state management. Omitting it leaves power state unmanaged after creation. A VM created with powered_on = false is initially started by Katapult's build process and then gracefully shut down before creation completes, so connection-based provisioners cannot run against the stopped result.
 ---
 
 # katapult_virtual_machine (Resource)
@@ -12,6 +13,8 @@ description: |-
 Manages a Virtual Machine in Katapult.
 
 ~> **Warning:** Deleting a virtual machine resource will by default purge the VM from Katapult's trash, permanently deleting it. Set `skip_trash_object_purge` on the provider to keep it in the trash instead.
+
+Set `powered_on` explicitly to opt into ongoing power-state management. Omitting it leaves power state unmanaged after creation. A VM created with `powered_on = false` is initially started by Katapult's build process and then gracefully shut down before creation completes, so connection-based provisioners cannot run against the stopped result.
 
 ## Example Usage
 
@@ -40,6 +43,10 @@ resource "katapult_virtual_machine" "base" {
   name        = "Web 2"
   hostname    = "web-2"
   description = "A web server."
+
+  # Explicitly opt into ongoing power-state management. Set this to false to
+  # gracefully shut down the VM and keep it stopped.
+  powered_on = true
 
   group_id = katapult_virtual_machine_group.web.id
   tags     = ["web", "public"]
@@ -79,7 +86,7 @@ resource "katapult_virtual_machine" "base" {
 
 - `disk_template` (String) Permalink or ID of the Disk Template to use.
 - `ip_address_ids` (Set of String) Set of IP address IDs to allocate to the Virtual Machine.
-- `package` (String) Permalink or ID of a Virtual Machine Package. Changing this will resize the Virtual Machine to the new package in place. Note: Downgrades (to packages with fewer vCPUs or memory) require the Virtual Machine to be stopped before the change can be applied.
+- `package` (String) Permalink or ID of a Virtual Machine Package. Changing this will resize the Virtual Machine to the new package in place. Note: Downgrades (to packages with fewer vCPUs or memory) require the Virtual Machine to be stopped. To stop and downgrade in one apply, explicitly set `powered_on = false`; set it to true in a later apply to start the VM again.
 
 ### Optional
 
@@ -90,6 +97,7 @@ resource "katapult_virtual_machine" "base" {
 - `hostname` (String) The hostname of the Virtual Machine. If not provided, a hostname is generated.
 - `name` (String) The name of the Virtual Machine. If not provided, a name is generated automatically.
 - `network_speed_profile` (String) Permalink of the Network Speed Profile to apply to all network interfaces.
+- `powered_on` (Boolean) Whether the Virtual Machine should be powered on. Set this explicitly to opt into ongoing power state management; omit it to observe power state without managing it. Powering off uses a graceful shutdown.
 - `tags` (Set of String) Set of tag names to assign to the Virtual Machine.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `virtual_network_ids` (Set of String) Set of Virtual Network IDs to attach to the Virtual Machine.

--- a/examples/resources/katapult_virtual_machine/resource.tf
+++ b/examples/resources/katapult_virtual_machine/resource.tf
@@ -23,6 +23,10 @@ resource "katapult_virtual_machine" "base" {
   hostname    = "web-2"
   description = "A web server."
 
+  # Explicitly opt into ongoing power-state management. Set this to false to
+  # gracefully shut down the VM and keep it stopped.
+  powered_on = true
+
   group_id = katapult_virtual_machine_group.web.id
   tags     = ["web", "public"]
 

--- a/internal/v6provider/resource_virtual_machine.go
+++ b/internal/v6provider/resource_virtual_machine.go
@@ -77,7 +77,10 @@ type virtualMachinePackageReader interface {
 	) (*core.GetVirtualMachinePackageResponse, error)
 }
 
-const virtualMachineDiskSizeAttribute = "size"
+const (
+	virtualMachineDiskSizeAttribute   = "size"
+	virtualMachineShutdownActionLabel = "shutdown"
+)
 
 var vmNetworkInterfaceAttrTypes = map[string]attr.Type{
 	"id":                 types.StringType,
@@ -1641,46 +1644,20 @@ func reconcileVirtualMachinePowerState(
 				"cannot reconcile virtual machine %s from terminal state %s to %s",
 				vmID, state, target,
 			)
-		case core.Starting:
-			if err = waitForVirtualMachineState(
-				ctx, m, vmID, virtualMachineExactStatePending(core.Started),
-				[]core.VirtualMachineStateEnum{core.Started}, timeout,
+		case core.Starting, core.Stopping, core.ShuttingDown:
+			if err = waitForVirtualMachineStableState(
+				ctx, m, vmID, timeout,
 			); err != nil {
-				return virtualMachineStateWaitError(vmID, state, core.Started, err)
-			}
-			if target == core.Started {
-				return nil
-			}
-			continue
-		case core.Stopping, core.ShuttingDown:
-			if err = waitForVirtualMachineState(
-				ctx, m, vmID, virtualMachineExactStatePending(core.Stopped),
-				[]core.VirtualMachineStateEnum{core.Stopped}, timeout,
-			); err != nil {
-				return virtualMachineStateWaitError(vmID, state, core.Stopped, err)
-			}
-			if target == core.Stopped {
-				return nil
+				return fmt.Errorf(
+					"error waiting for virtual machine %s to settle from %s: %w",
+					vmID, state, err,
+				)
 			}
 			continue
 		case core.Allocated, core.Allocating, core.Resetting, core.Migrating,
 			core.Transferring:
-			if err = waitForVirtualMachineState(
-				ctx,
-				m,
-				vmID,
-				[]core.VirtualMachineStateEnum{
-					core.Allocated,
-					core.Allocating,
-					core.Resetting,
-					core.Migrating,
-					core.Transferring,
-					core.Starting,
-					core.Stopping,
-					core.ShuttingDown,
-				},
-				[]core.VirtualMachineStateEnum{core.Started, core.Stopped},
-				timeout,
+			if err = waitForVirtualMachineStableState(
+				ctx, m, vmID, timeout,
 			); err != nil {
 				return fmt.Errorf(
 					"error waiting for virtual machine %s to settle from %s: %w",
@@ -1757,7 +1734,7 @@ func queueVirtualMachinePowerAction(
 		return *res.JSON200.Task.Id, action, nil
 	}
 
-	action = "shutdown"
+	action = virtualMachineShutdownActionLabel
 	res, actionErr := m.Core.PostVirtualMachineShutdownWithResponse(
 		ctx,
 		core.PostVirtualMachineShutdownJSONRequestBody{VirtualMachine: lookup},
@@ -1843,6 +1820,31 @@ func waitForVirtualMachineState(
 	}
 
 	return nil
+}
+
+func waitForVirtualMachineStableState(
+	ctx context.Context,
+	m *Meta,
+	vmID string,
+	timeout time.Duration,
+) error {
+	return waitForVirtualMachineState(
+		ctx,
+		m,
+		vmID,
+		[]core.VirtualMachineStateEnum{
+			core.Allocated,
+			core.Allocating,
+			core.Resetting,
+			core.Migrating,
+			core.Transferring,
+			core.Starting,
+			core.Stopping,
+			core.ShuttingDown,
+		},
+		[]core.VirtualMachineStateEnum{core.Started, core.Stopped},
+		timeout,
+	)
 }
 
 func virtualMachineExactStatePending(

--- a/internal/v6provider/resource_virtual_machine.go
+++ b/internal/v6provider/resource_virtual_machine.go
@@ -43,6 +43,7 @@ type (
 		Description         types.String   `tfsdk:"description"`
 		FQDN                types.String   `tfsdk:"fqdn"`
 		State               types.String   `tfsdk:"state"`
+		PoweredOn           types.Bool     `tfsdk:"powered_on"`
 		Package             types.String   `tfsdk:"package"`
 		DiskTemplate        types.String   `tfsdk:"disk_template"`
 		DiskTemplateOptions types.Map      `tfsdk:"disk_template_options"`
@@ -159,11 +160,20 @@ func (r *VirtualMachineResource) ModifyPlan(
 		return
 	}
 
+	var poweredOn types.Bool
+	resp.Diagnostics.Append(
+		req.Config.GetAttribute(ctx, path.Root("powered_on"), &poweredOn)...,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	err := validateVirtualMachinePackageChange(
 		ctx,
 		r.M.Core,
 		state.ID.ValueString(),
 		plan.Package.ValueString(),
+		poweredOn,
 	)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
@@ -184,7 +194,13 @@ func (r *VirtualMachineResource) Schema( //nolint:funlen
 			"~> **Warning:** Deleting a virtual machine resource will by " +
 			"default purge the VM from Katapult's trash, permanently " +
 			"deleting it. Set `skip_trash_object_purge` on the " +
-			"provider to keep it in the trash instead.",
+			"provider to keep it in the trash instead.\n\n" +
+			"Set `powered_on` explicitly to opt into ongoing power-state " +
+			"management. Omitting it leaves power state unmanaged after " +
+			"creation. A VM created with `powered_on = false` is initially " +
+			"started by Katapult's build process and then gracefully shut " +
+			"down before creation completes, so connection-based provisioners " +
+			"cannot run against the stopped result.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -231,14 +247,23 @@ func (r *VirtualMachineResource) Schema( //nolint:funlen
 				MarkdownDescription: "The current state of the " +
 					"Virtual Machine.",
 			},
+			"powered_on": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "Whether the Virtual Machine should be " +
+					"powered on. Set this explicitly to opt into ongoing power " +
+					"state management; omit it to observe power state without " +
+					"managing it. Powering off uses a graceful shutdown.",
+			},
 			"package": schema.StringAttribute{
 				Required: true,
 				MarkdownDescription: "Permalink or ID of a Virtual Machine " +
 					"Package. Changing this will resize the Virtual Machine " +
 					"to the new package in place. Note: Downgrades (to " +
 					"packages with fewer vCPUs or memory) require the " +
-					"Virtual Machine to be stopped before the change can be " +
-					"applied.",
+					"Virtual Machine to be stopped. To stop and downgrade in " +
+					"one apply, explicitly set `powered_on = false`; set it " +
+					"to true in a later apply to start the VM again.",
 				Validators: []validator.String{
 					stringValidatorNotEmpty(),
 				},
@@ -395,6 +420,14 @@ func (r *VirtualMachineResource) Create( //nolint:funlen,gocyclo
 ) {
 	var plan VirtualMachineResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var configuredPoweredOn types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(
+		ctx, path.Root("powered_on"), &configuredPoweredOn,
+	)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -789,6 +822,17 @@ func (r *VirtualMachineResource) Create( //nolint:funlen,gocyclo
 		return
 	}
 
+	if !configuredPoweredOn.IsNull() &&
+		!configuredPoweredOn.IsUnknown() &&
+		!configuredPoweredOn.ValueBool() {
+		if err = reconcileVirtualMachinePowerState(
+			ctx, r.M, vmID, false, timeout,
+		); err != nil {
+			resp.Diagnostics.AddError("Create Error", err.Error())
+			return
+		}
+	}
+
 	if err := r.vmRead(ctx, &plan); err != nil {
 		resp.Diagnostics.AddError("Read Error", err.Error())
 		return
@@ -844,6 +888,25 @@ func (r *VirtualMachineResource) Update( //nolint:funlen,gocyclo
 		return
 	}
 	vmID := state.ID.ValueString()
+
+	var configuredPoweredOn types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(
+		ctx, path.Root("powered_on"), &configuredPoweredOn,
+	)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	powerManaged := !configuredPoweredOn.IsNull() &&
+		!configuredPoweredOn.IsUnknown()
+
+	if powerManaged && !configuredPoweredOn.ValueBool() {
+		if err := reconcileVirtualMachinePowerState(
+			ctx, r.M, vmID, false, timeout,
+		); err != nil {
+			resp.Diagnostics.AddError("Update Error", err.Error())
+			return
+		}
+	}
 
 	if !plan.Package.Equal(state.Package) {
 		err := changeVirtualMachinePackage(
@@ -1119,6 +1182,15 @@ func (r *VirtualMachineResource) Update( //nolint:funlen,gocyclo
 			ctx, r.M, vmID, permalink, timeout,
 		); e != nil {
 			resp.Diagnostics.AddError("Update Error", e.Error())
+			return
+		}
+	}
+
+	if powerManaged && configuredPoweredOn.ValueBool() {
+		if err := reconcileVirtualMachinePowerState(
+			ctx, r.M, vmID, true, timeout,
+		); err != nil {
+			resp.Diagnostics.AddError("Update Error", err.Error())
 			return
 		}
 	}
@@ -1410,7 +1482,7 @@ func (r *VirtualMachineResource) vmRead(
 	model.FQDN = types.StringPointerValue(vm.Fqdn)
 
 	if vm.State != nil {
-		model.State = types.StringValue(string(*vm.State))
+		populateVirtualMachinePowerState(model, *vm.State)
 	}
 
 	if desc, err2 := vm.Description.Get(); err2 == nil && desc != "" {
@@ -1509,26 +1581,347 @@ func optionalOnlyStringAbsentValue(current types.String) types.String {
 	return types.StringNull()
 }
 
+func virtualMachinePoweredOnProjection(
+	state core.VirtualMachineStateEnum,
+	previous types.Bool,
+) types.Bool {
+	switch state { //nolint:exhaustive
+	case core.Started, core.Starting:
+		return types.BoolValue(true)
+	case core.Stopped, core.Stopping, core.ShuttingDown:
+		return types.BoolValue(false)
+	default:
+		if !previous.IsNull() && !previous.IsUnknown() {
+			return previous
+		}
+
+		return types.BoolNull()
+	}
+}
+
+func populateVirtualMachinePowerState(
+	model *VirtualMachineResourceModel,
+	state core.VirtualMachineStateEnum,
+) {
+	model.State = types.StringValue(string(state))
+	model.PoweredOn = virtualMachinePoweredOnProjection(state, model.PoweredOn)
+}
+
+func reconcileVirtualMachinePowerState(
+	ctx context.Context,
+	m *Meta,
+	vmID string,
+	poweredOn bool,
+	timeout time.Duration,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	target := core.Stopped
+	if poweredOn {
+		target = core.Started
+	}
+
+	for {
+		state, err := fetchVirtualMachineState(ctx, m, vmID)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to fetch virtual machine %s while reconciling to %s: %w",
+				vmID, target, err,
+			)
+		}
+
+		if state == target {
+			return nil
+		}
+
+		switch state {
+		case core.Failed, core.Orphaned:
+			return fmt.Errorf(
+				"cannot reconcile virtual machine %s from terminal state %s to %s",
+				vmID, state, target,
+			)
+		case core.Starting:
+			if err = waitForVirtualMachineState(
+				ctx, m, vmID, virtualMachineExactStatePending(core.Started),
+				[]core.VirtualMachineStateEnum{core.Started}, timeout,
+			); err != nil {
+				return virtualMachineStateWaitError(vmID, state, core.Started, err)
+			}
+			if target == core.Started {
+				return nil
+			}
+			continue
+		case core.Stopping, core.ShuttingDown:
+			if err = waitForVirtualMachineState(
+				ctx, m, vmID, virtualMachineExactStatePending(core.Stopped),
+				[]core.VirtualMachineStateEnum{core.Stopped}, timeout,
+			); err != nil {
+				return virtualMachineStateWaitError(vmID, state, core.Stopped, err)
+			}
+			if target == core.Stopped {
+				return nil
+			}
+			continue
+		case core.Allocated, core.Allocating, core.Resetting, core.Migrating,
+			core.Transferring:
+			if err = waitForVirtualMachineState(
+				ctx,
+				m,
+				vmID,
+				[]core.VirtualMachineStateEnum{
+					core.Allocated,
+					core.Allocating,
+					core.Resetting,
+					core.Migrating,
+					core.Transferring,
+					core.Starting,
+					core.Stopping,
+					core.ShuttingDown,
+				},
+				[]core.VirtualMachineStateEnum{core.Started, core.Stopped},
+				timeout,
+			); err != nil {
+				return fmt.Errorf(
+					"error waiting for virtual machine %s to settle from %s: %w",
+					vmID, state, err,
+				)
+			}
+			continue
+		case core.Started, core.Stopped:
+			// Queue the required action below.
+		default:
+			return fmt.Errorf(
+				"cannot reconcile virtual machine %s from unsupported state %q to %s",
+				vmID, state, target,
+			)
+		}
+
+		taskID, action, err := queueVirtualMachinePowerAction(
+			ctx, m, vmID, poweredOn,
+		)
+		if err != nil {
+			return err
+		}
+		if err = waitForTaskCompletion(ctx, m, timeout, taskID); err != nil {
+			return fmt.Errorf(
+				"error waiting for virtual machine %s %s task: %w",
+				vmID, action, err,
+			)
+		}
+		if err = waitForVirtualMachineState(
+			ctx,
+			m,
+			vmID,
+			virtualMachineExactStatePending(target),
+			[]core.VirtualMachineStateEnum{target},
+			timeout,
+		); err != nil {
+			return virtualMachineStateWaitError(vmID, state, target, err)
+		}
+
+		return nil
+	}
+}
+
+func queueVirtualMachinePowerAction(
+	ctx context.Context,
+	m *Meta,
+	vmID string,
+	poweredOn bool,
+) (taskID string, action string, err error) {
+	lookup := core.VirtualMachineLookup{Id: &vmID}
+	if poweredOn {
+		action = "start"
+		res, actionErr := m.Core.PostVirtualMachineStartWithResponse(
+			ctx,
+			core.PostVirtualMachineStartJSONRequestBody{VirtualMachine: lookup},
+		)
+		if actionErr != nil {
+			if res != nil {
+				actionErr = genericAPIError(actionErr, res.Body)
+			}
+			return "", action, fmt.Errorf(
+				"failed to queue start for virtual machine %s: %w",
+				vmID, actionErr,
+			)
+		}
+		if res == nil || res.JSON200 == nil || res.JSON200.Task.Id == nil ||
+			*res.JSON200.Task.Id == "" {
+			return "", action, fmt.Errorf(
+				"unexpected empty task response queueing start for virtual machine %s",
+				vmID,
+			)
+		}
+
+		return *res.JSON200.Task.Id, action, nil
+	}
+
+	action = "shutdown"
+	res, actionErr := m.Core.PostVirtualMachineShutdownWithResponse(
+		ctx,
+		core.PostVirtualMachineShutdownJSONRequestBody{VirtualMachine: lookup},
+	)
+	if actionErr != nil {
+		if res != nil {
+			actionErr = genericAPIError(actionErr, res.Body)
+		}
+		return "", action, fmt.Errorf(
+			"failed to queue graceful shutdown for virtual machine %s: %w",
+			vmID, actionErr,
+		)
+	}
+	if res == nil || res.JSON200 == nil || res.JSON200.Task.Id == nil ||
+		*res.JSON200.Task.Id == "" {
+		return "", action, fmt.Errorf(
+			"unexpected empty task response queueing graceful shutdown for virtual machine %s",
+			vmID,
+		)
+	}
+
+	return *res.JSON200.Task.Id, action, nil
+}
+
+func fetchVirtualMachineState(
+	ctx context.Context,
+	m *Meta,
+	vmID string,
+) (core.VirtualMachineStateEnum, error) {
+	res, err := m.Core.GetVirtualMachineWithResponse(
+		ctx,
+		&core.GetVirtualMachineParams{VirtualMachineId: &vmID},
+	)
+	if err != nil {
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
+		return "", err
+	}
+	if res == nil || res.JSON200 == nil {
+		return "", fmt.Errorf("unexpected empty response polling VM state")
+	}
+	if res.JSON200.VirtualMachine.State == nil {
+		return "", fmt.Errorf("virtual machine state is nil")
+	}
+
+	return *res.JSON200.VirtualMachine.State, nil
+}
+
+func waitForVirtualMachineState(
+	ctx context.Context,
+	m *Meta,
+	vmID string,
+	pending []core.VirtualMachineStateEnum,
+	target []core.VirtualMachineStateEnum,
+	timeout time.Duration,
+) error {
+	waiter := &retry.StateChangeConf{
+		Pending:                   virtualMachineStateStrings(pending),
+		Target:                    virtualMachineStateStrings(target),
+		Timeout:                   timeout,
+		Delay:                     m.stateChangeDelay(1 * time.Second),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
+		ContinuousTargetOccurence: 1,
+	}
+	waiter.Refresh = func() (interface{}, string, error) {
+		state, err := fetchVirtualMachineState(ctx, m, vmID)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return state, string(state), nil
+	}
+
+	raw, err := waiter.WaitForStateContext(ctx)
+	if err != nil {
+		return err
+	}
+	_, ok := raw.(core.VirtualMachineStateEnum)
+	if !ok {
+		return fmt.Errorf("unexpected virtual machine state result %T", raw)
+	}
+
+	return nil
+}
+
+func virtualMachineExactStatePending(
+	target core.VirtualMachineStateEnum,
+) []core.VirtualMachineStateEnum {
+	states := []core.VirtualMachineStateEnum{
+		core.Allocated,
+		core.Allocating,
+		core.Migrating,
+		core.Resetting,
+		core.ShuttingDown,
+		core.Started,
+		core.Starting,
+		core.Stopped,
+		core.Stopping,
+		core.Transferring,
+	}
+	pending := make([]core.VirtualMachineStateEnum, 0, len(states)-1)
+	for _, state := range states {
+		if state != target {
+			pending = append(pending, state)
+		}
+	}
+
+	return pending
+}
+
+func virtualMachineStateStrings(
+	states []core.VirtualMachineStateEnum,
+) []string {
+	values := make([]string, len(states))
+	for i, state := range states {
+		values[i] = string(state)
+	}
+
+	return values
+}
+
+func virtualMachineStateWaitError(
+	vmID string,
+	from core.VirtualMachineStateEnum,
+	target core.VirtualMachineStateEnum,
+	err error,
+) error {
+	return fmt.Errorf(
+		"error waiting for virtual machine %s to reach %s from %s: %w",
+		vmID, target, from, err,
+	)
+}
+
 // validateVirtualMachinePackageChange fails when a package change would
-// downgrade a running Virtual Machine. Katapult requires the VM to be stopped
-// before its vCPU count or memory can be reduced.
+// downgrade a Virtual Machine that cannot be stopped by the same apply.
+// Katapult requires the VM to be stopped before its vCPU count or memory can
+// be reduced.
 func validateVirtualMachinePackageChange(
 	ctx context.Context,
 	client virtualMachinePackageReader,
 	vmID string,
 	pkgRef string,
+	poweredOn types.Bool,
 ) error {
 	vm, err := virtualMachineForPackageValidation(ctx, client, vmID)
 	if err != nil {
 		return err
 	}
-	if vm == nil || vm.State == nil || *vm.State != core.Started ||
-		!vm.Package.IsSpecified() || vm.Package.IsNull() {
+	if vm == nil {
 		return nil
+	}
+	if !vm.Package.IsSpecified() || vm.Package.IsNull() {
+		return fmt.Errorf("virtual machine response is missing package details")
 	}
 
 	currentPkg, _ := vm.Package.Get()
 	if virtualMachinePackageMatches(currentPkg, pkgRef) {
+		return nil
+	}
+	// Every package change is safe while the VM is already stopped, so there
+	// is no need to fetch the target package merely to classify the change.
+	if vm.State != nil && *vm.State == core.Stopped {
 		return nil
 	}
 
@@ -1544,11 +1937,27 @@ func validateVirtualMachinePackageChange(
 
 	if *newPkg.CpuCores < *currentPkg.CpuCores ||
 		*newPkg.MemoryInGb < *currentPkg.MemoryInGb {
+		if vm.State == nil {
+			return fmt.Errorf("virtual machine response is missing state")
+		}
+		allowed, stateErr := virtualMachineDowngradeAllowed(
+			*vm.State, poweredOn,
+		)
+		if stateErr != nil {
+			return stateErr
+		}
+		if allowed {
+			return nil
+		}
+
 		return fmt.Errorf(
-			"cannot downgrade package while Virtual Machine is running: "+
+			"cannot downgrade package unless the Virtual Machine is already "+
+				"stopped or powered_on = false is explicitly configured in "+
+				"the same plan: "+
 				"current package has %d vCPU(s) and %dGB memory, new "+
-				"package has %d vCPU(s) and %dGB memory. Stop the "+
-				"Virtual Machine before downgrading",
+				"package has %d vCPU(s) and %dGB memory. Apply the "+
+				"downgrade with powered_on = false, then set it to true "+
+				"in a later apply to start the Virtual Machine again",
 			*currentPkg.CpuCores,
 			*currentPkg.MemoryInGb,
 			*newPkg.CpuCores,
@@ -1557,6 +1966,31 @@ func validateVirtualMachinePackageChange(
 	}
 
 	return nil
+}
+
+func virtualMachineDowngradeAllowed(
+	state core.VirtualMachineStateEnum,
+	poweredOn types.Bool,
+) (bool, error) {
+	switch state {
+	case core.Stopped:
+		return true, nil
+	case core.Failed, core.Orphaned:
+		return false, fmt.Errorf(
+			"cannot downgrade package while Virtual Machine is in %s state",
+			state,
+		)
+	case core.Started, core.Starting, core.Stopping, core.ShuttingDown,
+		core.Allocated, core.Allocating, core.Resetting, core.Migrating,
+		core.Transferring:
+		return !poweredOn.IsNull() && !poweredOn.IsUnknown() &&
+			!poweredOn.ValueBool(), nil
+	default:
+		return false, fmt.Errorf(
+			"cannot downgrade package while Virtual Machine is in unsupported state %q",
+			state,
+		)
+	}
 }
 
 func virtualMachineForPackageValidation(
@@ -2232,45 +2666,18 @@ func waitForVMToStop(
 	vmID string,
 	timeout time.Duration,
 ) error {
-	waiter := &retry.StateChangeConf{
-		Pending: []string{
-			string(core.Started),
-			string(core.Stopping),
-			string(core.ShuttingDown),
+	err := waitForVirtualMachineState(
+		ctx,
+		m,
+		vmID,
+		[]core.VirtualMachineStateEnum{
+			core.Started,
+			core.Stopping,
+			core.ShuttingDown,
 		},
-		Target: []string{
-			string(core.Stopped),
-		},
-		Refresh: func() (interface{}, string, error) {
-			res, e := m.Core.GetVirtualMachineWithResponse(ctx,
-				&core.GetVirtualMachineParams{
-					VirtualMachineId: &vmID,
-				})
-			if e != nil {
-				if res != nil {
-					e = genericAPIError(e, res.Body)
-				}
-				return nil, "", e
-			}
-			if res.JSON200 == nil {
-				return nil, "", fmt.Errorf(
-					"unexpected empty response polling VM state",
-				)
-			}
-			v := res.JSON200.VirtualMachine
-			if v.State == nil {
-				return v, "", fmt.Errorf("vm state is nil")
-			}
-			return v, string(*v.State), nil
-		},
-		Timeout:                   timeout,
-		Delay:                     m.stateChangeDelay(1 * time.Second),
-		MinTimeout:                m.stateChangeDelay(5 * time.Second),
-		PollInterval:              m.stateChangePollInterval(),
-		ContinuousTargetOccurence: 1,
-	}
-
-	_, err := waiter.WaitForStateContext(ctx)
+		[]core.VirtualMachineStateEnum{core.Stopped},
+		timeout,
+	)
 
 	return err
 }

--- a/internal/v6provider/resource_virtual_machine_package_acceptance_test.go
+++ b/internal/v6provider/resource_virtual_machine_package_acceptance_test.go
@@ -102,7 +102,7 @@ func TestAccKatapultVirtualMachine_update_package_downgrade_error(
 			{
 				Config: virtualMachinePackageTestConfig(name, "rock-1"),
 				ExpectError: regexp.MustCompile(
-					"cannot downgrade package while Virtual Machine is running",
+					"cannot downgrade package unless the Virtual Machine is already",
 				),
 			},
 		},

--- a/internal/v6provider/resource_virtual_machine_package_acceptance_test.go
+++ b/internal/v6provider/resource_virtual_machine_package_acceptance_test.go
@@ -139,6 +139,73 @@ func TestAccKatapultVirtualMachine_update_package_downgrade_stopped(
 	})
 }
 
+func TestAccKatapultVirtualMachine_update_package_downgrade_powered_off(
+	t *testing.T,
+) {
+	tt := newTestTools(t)
+	name := tt.ResourceName("package-downgrade-power")
+	var vmID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckKatapultVirtualMachineDestroy(tt),
+			testAccCheckKatapultIPDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: virtualMachineManagedPackageTestConfig(
+					name,
+					"rock-3",
+					true,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					virtualMachinePackageTestChecks("rock-3", &vmID, false),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base", "state", "started",
+					),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base", "powered_on", "true",
+					),
+				),
+			},
+			{
+				Config: virtualMachineManagedPackageTestConfig(
+					name,
+					"rock-1",
+					false,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					virtualMachinePackageTestChecks("rock-1", &vmID, true),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base", "state", "stopped",
+					),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base", "powered_on", "false",
+					),
+				),
+			},
+			{
+				Config: virtualMachineManagedPackageTestConfig(
+					name,
+					"rock-1",
+					true,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					virtualMachinePackageTestChecks("rock-1", &vmID, true),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base", "state", "started",
+					),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base", "powered_on", "true",
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKatapultVirtualMachine_update_package_upgrade_stopped(
 	t *testing.T,
 ) {
@@ -190,6 +257,36 @@ func virtualMachinePackageTestConfig(name string, pkg string) string {
 		name,
 		name+"-host",
 		pkg,
+	)
+}
+
+func virtualMachineManagedPackageTestConfig(
+	name string,
+	pkg string,
+	poweredOn bool,
+) string {
+	return undent.Stringf(`
+		resource "katapult_ip" "web" {}
+
+		resource "katapult_virtual_machine" "base" {
+			name          = "%s"
+			hostname      = "%s"
+			package       = "%s"
+			powered_on    = %t
+			disk_template = "ubuntu-18-04"
+			disk_template_options = {
+				install_agent = true
+			}
+			ip_address_ids = [katapult_ip.web.id]
+
+			timeouts {
+				update = "10m"
+			}
+		}`,
+		name,
+		name+"-host",
+		pkg,
+		poweredOn,
 	)
 }
 

--- a/internal/v6provider/resource_virtual_machine_package_test.go
+++ b/internal/v6provider/resource_virtual_machine_package_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/krystal/go-katapult/next/core"
 )
 
@@ -22,18 +23,77 @@ func TestValidateVirtualMachinePackageChange(t *testing.T) {
 		packageRef        string
 		targetCPUCores    int
 		targetMemoryInGB  int
+		poweredOn         types.Bool
 		wantErr           string
 		wantPackageLookup bool
 		wantPackageID     bool
 	}{
 		{
-			name:             "running downgrade",
-			state:            "started",
-			packageRef:       "rock-1",
-			targetCPUCores:   1,
-			targetMemoryInGB: 2,
-			wantErr: "cannot downgrade package while Virtual Machine " +
-				"is running",
+			name:              "running downgrade unmanaged",
+			state:             "started",
+			packageRef:        "rock-1",
+			targetCPUCores:    1,
+			targetMemoryInGB:  2,
+			poweredOn:         types.BoolNull(),
+			wantErr:           "powered_on = false",
+			wantPackageLookup: true,
+		},
+		{
+			name:              "running downgrade explicitly off",
+			state:             "started",
+			packageRef:        "rock-1",
+			targetCPUCores:    1,
+			targetMemoryInGB:  2,
+			poweredOn:         types.BoolValue(false),
+			wantPackageLookup: true,
+		},
+		{
+			name:              "running downgrade explicitly on",
+			state:             "started",
+			packageRef:        "rock-1",
+			targetCPUCores:    1,
+			targetMemoryInGB:  2,
+			poweredOn:         types.BoolValue(true),
+			wantErr:           "powered_on = false",
+			wantPackageLookup: true,
+		},
+		{
+			name:              "running downgrade unknown power config",
+			state:             "started",
+			packageRef:        "rock-1",
+			targetCPUCores:    1,
+			targetMemoryInGB:  2,
+			poweredOn:         types.BoolUnknown(),
+			wantErr:           "powered_on = false",
+			wantPackageLookup: true,
+		},
+		{
+			name:              "starting downgrade explicitly off",
+			state:             "starting",
+			packageRef:        "rock-1",
+			targetCPUCores:    1,
+			targetMemoryInGB:  2,
+			poweredOn:         types.BoolValue(false),
+			wantPackageLookup: true,
+		},
+		{
+			name:              "failed downgrade explicitly off",
+			state:             "failed",
+			packageRef:        "rock-1",
+			targetCPUCores:    1,
+			targetMemoryInGB:  2,
+			poweredOn:         types.BoolValue(false),
+			wantErr:           "failed state",
+			wantPackageLookup: true,
+		},
+		{
+			name:              "future state downgrade explicitly off",
+			state:             "future",
+			packageRef:        "rock-1",
+			targetCPUCores:    1,
+			targetMemoryInGB:  2,
+			poweredOn:         types.BoolValue(false),
+			wantErr:           "unsupported state",
 			wantPackageLookup: true,
 		},
 		{
@@ -45,9 +105,18 @@ func TestValidateVirtualMachinePackageChange(t *testing.T) {
 			wantPackageLookup: true,
 		},
 		{
-			name:       "stopped downgrade",
+			name:              "failed upgrade",
+			state:             "failed",
+			packageRef:        "rock-5",
+			targetCPUCores:    4,
+			targetMemoryInGB:  8,
+			wantPackageLookup: true,
+		},
+		{
+			name:       "stopped downgrade unmanaged",
 			state:      "stopped",
 			packageRef: "rock-1",
+			poweredOn:  types.BoolNull(),
 		},
 		{
 			name:       "same package by id",
@@ -127,6 +196,7 @@ func TestValidateVirtualMachinePackageChange(t *testing.T) {
 
 			err = validateVirtualMachinePackageChange(
 				context.Background(), client, "vm_test", tt.packageRef,
+				tt.poweredOn,
 			)
 			switch {
 			case tt.wantErr == "" && err != nil:

--- a/internal/v6provider/resource_virtual_machine_power_acceptance_test.go
+++ b/internal/v6provider/resource_virtual_machine_power_acceptance_test.go
@@ -1,0 +1,207 @@
+package v6provider
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jimeh/undent"
+	"github.com/krystal/go-katapult/next/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccKatapultVirtualMachine_power_state(t *testing.T) {
+	tt := newTestTools(t)
+	name := tt.ResourceName()
+	poweredOn := true
+	poweredOff := false
+	var vmID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckKatapultVirtualMachineDestroy(tt),
+			testAccCheckKatapultIPDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: virtualMachinePowerTestConfig(name, &poweredOff),
+				Check: virtualMachinePowerTestChecks(
+					"stopped", false, &vmID, false,
+				),
+			},
+			{
+				Config: virtualMachinePowerTestConfig(name, &poweredOn),
+				Check: virtualMachinePowerTestChecks(
+					"started", true, &vmID, true,
+				),
+			},
+			{
+				PreConfig: func() {
+					shutdownVirtualMachineForPowerTest(tt, vmID)
+				},
+				Config: virtualMachinePowerTestConfig(name, &poweredOn),
+				Check: virtualMachinePowerTestChecks(
+					"started", true, &vmID, true,
+				),
+			},
+			{
+				Config: virtualMachinePowerTestConfig(name, &poweredOff),
+				Check: virtualMachinePowerTestChecks(
+					"stopped", false, &vmID, true,
+				),
+			},
+			{
+				PreConfig: func() {
+					startVirtualMachineForPowerTest(tt, vmID)
+				},
+				Config: virtualMachinePowerTestConfig(name, &poweredOff),
+				Check: virtualMachinePowerTestChecks(
+					"stopped", false, &vmID, true,
+				),
+			},
+			{
+				Config: virtualMachinePowerTestConfig(name, nil),
+				Check: virtualMachinePowerTestChecks(
+					"stopped", false, &vmID, true,
+				),
+			},
+			{
+				PreConfig: func() {
+					startVirtualMachineForPowerTest(tt, vmID)
+				},
+				Config: virtualMachinePowerTestConfig(name, nil),
+				Check: virtualMachinePowerTestChecks(
+					"started", true, &vmID, true,
+				),
+			},
+		},
+	})
+}
+
+func virtualMachinePowerTestConfig(name string, poweredOn *bool) string {
+	poweredOnConfig := ""
+	if poweredOn != nil {
+		poweredOnConfig = fmt.Sprintf("powered_on = %t", *poweredOn)
+	}
+
+	return undent.Stringf(`
+		resource "katapult_ip" "web" {}
+
+		resource "katapult_virtual_machine" "base" {
+			name          = "%s"
+			hostname      = "%s"
+			package       = "rock-1"
+			disk_template = "ubuntu-18-04"
+			disk_template_options = {
+				install_agent = true
+			}
+			ip_address_ids = [katapult_ip.web.id]
+			%s
+
+			timeouts {
+				create = "20m"
+				update = "10m"
+				delete = "10m"
+			}
+		}`,
+		name,
+		name+"-host",
+		poweredOnConfig,
+	)
+}
+
+func virtualMachinePowerTestChecks(
+	state string,
+	poweredOn bool,
+	vmID *string,
+	wantExistingID bool,
+) resource.TestCheckFunc {
+	idCheck := captureResourceAttr(
+		"katapult_virtual_machine.base",
+		"id",
+		vmID,
+	)
+	if wantExistingID {
+		idCheck = resource.TestCheckResourceAttrPtr(
+			"katapult_virtual_machine.base",
+			"id",
+			vmID,
+		)
+	}
+
+	return resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(
+			"katapult_virtual_machine.base",
+			"state",
+			state,
+		),
+		resource.TestCheckResourceAttr(
+			"katapult_virtual_machine.base",
+			"powered_on",
+			fmt.Sprintf("%t", poweredOn),
+		),
+		idCheck,
+	)
+}
+
+func shutdownVirtualMachineForPowerTest(tt *testTools, vmID string) {
+	tt.T.Helper()
+
+	res, err := tt.Meta.Core.PostVirtualMachineShutdownWithResponse(
+		tt.Ctx,
+		core.PostVirtualMachineShutdownJSONRequestBody{
+			VirtualMachine: core.VirtualMachineLookup{Id: &vmID},
+		},
+	)
+	require.NoError(tt.T, err, "failed to shut down virtual machine")
+	require.NotNil(tt.T, res, "shutdown response is missing")
+	require.NotNil(tt.T, res.JSON200, "shutdown response body is missing")
+	require.NotNil(tt.T, res.JSON200.Task.Id, "shutdown task ID is missing")
+	waitForVirtualMachinePowerTest(tt, vmID, *res.JSON200.Task.Id, core.Stopped)
+}
+
+func startVirtualMachineForPowerTest(tt *testTools, vmID string) {
+	tt.T.Helper()
+
+	res, err := tt.Meta.Core.PostVirtualMachineStartWithResponse(
+		tt.Ctx,
+		core.PostVirtualMachineStartJSONRequestBody{
+			VirtualMachine: core.VirtualMachineLookup{Id: &vmID},
+		},
+	)
+	require.NoError(tt.T, err, "failed to start virtual machine")
+	require.NotNil(tt.T, res, "start response is missing")
+	require.NotNil(tt.T, res.JSON200, "start response body is missing")
+	require.NotNil(tt.T, res.JSON200.Task.Id, "start task ID is missing")
+	waitForVirtualMachinePowerTest(tt, vmID, *res.JSON200.Task.Id, core.Started)
+}
+
+func waitForVirtualMachinePowerTest(
+	tt *testTools,
+	vmID string,
+	taskID string,
+	target core.VirtualMachineStateEnum,
+) {
+	tt.T.Helper()
+
+	err := waitForTaskCompletion(tt.Ctx, tt.Meta, 5*time.Minute, taskID)
+	require.NoError(tt.T, err, "virtual machine power task failed")
+
+	err = waitForVirtualMachineState(
+		tt.Ctx,
+		tt.Meta,
+		vmID,
+		virtualMachineExactStatePending(target),
+		[]core.VirtualMachineStateEnum{target},
+		5*time.Minute,
+	)
+	require.NoError(
+		tt.T,
+		err,
+		"virtual machine did not reach %s state",
+		target,
+	)
+}

--- a/internal/v6provider/resource_virtual_machine_power_test.go
+++ b/internal/v6provider/resource_virtual_machine_power_test.go
@@ -1,0 +1,289 @@
+package v6provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/krystal/go-katapult/next/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVirtualMachinePoweredOnProjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		state    core.VirtualMachineStateEnum
+		previous types.Bool
+		want     types.Bool
+	}{
+		{name: "started", state: core.Started, want: types.BoolValue(true)},
+		{name: "starting", state: core.Starting, want: types.BoolValue(true)},
+		{name: "stopped", state: core.Stopped, want: types.BoolValue(false)},
+		{name: "stopping", state: core.Stopping, want: types.BoolValue(false)},
+		{
+			name:  "shutting down",
+			state: core.ShuttingDown,
+			want:  types.BoolValue(false),
+		},
+		{
+			name:     "migrating preserves known value",
+			state:    core.Migrating,
+			previous: types.BoolValue(true),
+			want:     types.BoolValue(true),
+		},
+		{
+			name:  "failed remains unknown without previous value",
+			state: core.Failed,
+			want:  types.BoolNull(),
+		},
+		{
+			name:     "future state preserves known value",
+			state:    core.VirtualMachineStateEnum("future"),
+			previous: types.BoolValue(false),
+			want:     types.BoolValue(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := virtualMachinePoweredOnProjection(tt.state, tt.previous)
+			require.True(t, got.Equal(tt.want), "got %s, want %s", got, tt.want)
+		})
+	}
+}
+
+func TestVirtualMachinePowerReconciliation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		poweredOn    bool
+		states       []core.VirtualMachineStateEnum
+		wantAction   string
+		wantEndpoint string
+	}{
+		{
+			name:      "started target on is a no-op",
+			poweredOn: true,
+			states:    []core.VirtualMachineStateEnum{core.Started},
+		},
+		{
+			name:         "started target off queues graceful shutdown",
+			states:       []core.VirtualMachineStateEnum{core.Started, core.Stopped},
+			wantAction:   "shutdown",
+			wantEndpoint: "/virtual_machines/virtual_machine/shutdown",
+		},
+		{
+			name:         "stopped target on queues start",
+			poweredOn:    true,
+			states:       []core.VirtualMachineStateEnum{core.Stopped, core.Started},
+			wantAction:   "start",
+			wantEndpoint: "/virtual_machines/virtual_machine/start",
+		},
+		{
+			name:      "starting target on waits without duplicate action",
+			poweredOn: true,
+			states:    []core.VirtualMachineStateEnum{core.Starting, core.Started},
+		},
+		{
+			name:   "shutting down target off waits without duplicate action",
+			states: []core.VirtualMachineStateEnum{core.ShuttingDown, core.Stopped},
+		},
+		{
+			name:      "opposite transition settles before shutdown",
+			poweredOn: false,
+			states: []core.VirtualMachineStateEnum{
+				core.Starting, core.Started, core.Started, core.Stopped,
+			},
+			wantAction:   "shutdown",
+			wantEndpoint: "/virtual_machines/virtual_machine/shutdown",
+		},
+		{
+			name:      "ambiguous transition settles before start",
+			poweredOn: true,
+			states: []core.VirtualMachineStateEnum{
+				core.Migrating, core.Stopped, core.Stopped, core.Started,
+			},
+			wantAction:   "start",
+			wantEndpoint: "/virtual_machines/virtual_machine/start",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stateCall := 0
+			actionCalls := 0
+			var gotEndpoint string
+			client := newVirtualMachineTestClient(t, func(
+				w http.ResponseWriter,
+				r *http.Request,
+			) {
+				switch {
+				case r.Method == http.MethodGet &&
+					r.URL.Path == "/virtual_machines/virtual_machine":
+					index := stateCall
+					if index >= len(tt.states) {
+						index = len(tt.states) - 1
+					}
+					stateCall++
+					writeVirtualMachinePowerState(w, tt.states[index])
+				case r.Method == http.MethodPost &&
+					strings.HasPrefix(
+						r.URL.Path, "/virtual_machines/virtual_machine/",
+					):
+					actionCalls++
+					gotEndpoint = r.URL.Path
+					writeTestJSON(w, http.StatusOK, `{
+						"task": {"id": "task_power", "status": "pending"}
+					}`)
+				case r.Method == http.MethodGet &&
+					r.URL.Path == "/tasks/task":
+					writeTestJSON(w, http.StatusOK, `{
+						"task": {"id": "task_power", "status": "completed"}
+					}`)
+				default:
+					http.NotFound(w, r)
+				}
+			})
+			meta := &Meta{Core: client, testMode: true}
+
+			err := reconcileVirtualMachinePowerState(
+				context.Background(), meta, "vm_power", tt.poweredOn, time.Second,
+			)
+
+			require.NoError(t, err)
+			if tt.wantAction == "" {
+				require.Zero(t, actionCalls)
+			} else {
+				require.Equal(t, 1, actionCalls)
+				require.Equal(t, tt.wantEndpoint, gotEndpoint)
+			}
+		})
+	}
+}
+
+func TestVirtualMachinePowerReconciliationRejectsUnsafeStates(t *testing.T) {
+	t.Parallel()
+
+	for _, state := range []core.VirtualMachineStateEnum{
+		core.Failed,
+		core.Orphaned,
+		core.VirtualMachineStateEnum("future"),
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			t.Parallel()
+
+			actionCalls := 0
+			client := newVirtualMachineTestClient(t, func(
+				w http.ResponseWriter,
+				r *http.Request,
+			) {
+				if r.Method == http.MethodGet {
+					writeVirtualMachinePowerState(w, state)
+					return
+				}
+				actionCalls++
+				http.NotFound(w, r)
+			})
+
+			err := reconcileVirtualMachinePowerState(
+				context.Background(),
+				&Meta{Core: client, testMode: true},
+				"vm_unsafe",
+				true,
+				time.Second,
+			)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), string(state))
+			require.Zero(t, actionCalls)
+		})
+	}
+}
+
+func TestVirtualMachinePowerReconciliationActionFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		actionBody string
+		actionCode int
+		taskBody   string
+		wantErr    string
+	}{
+		{
+			name: "structured action error",
+			actionBody: `{
+				"error": {"code": "permission_denied", "description": "No access"}
+			}`,
+			actionCode: http.StatusForbidden,
+			wantErr:    "permission_denied: No access",
+		},
+		{
+			name:       "missing task id",
+			actionBody: `{"task": {"status": "pending"}}`,
+			actionCode: http.StatusOK,
+			wantErr:    "unexpected empty task response",
+		},
+		{
+			name:       "failed task",
+			actionBody: `{"task": {"id": "task_failed", "status": "pending"}}`,
+			actionCode: http.StatusOK,
+			taskBody:   `{"task": {"id": "task_failed", "status": "failed"}}`,
+			wantErr:    "shutdown task: task failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := newVirtualMachineTestClient(t, func(
+				w http.ResponseWriter,
+				r *http.Request,
+			) {
+				switch r.URL.Path {
+				case "/virtual_machines/virtual_machine":
+					writeVirtualMachinePowerState(w, core.Started)
+				case "/virtual_machines/virtual_machine/shutdown":
+					writeTestJSON(w, tt.actionCode, tt.actionBody)
+				case "/tasks/task":
+					writeTestJSON(w, http.StatusOK, tt.taskBody)
+				default:
+					http.NotFound(w, r)
+				}
+			})
+
+			err := reconcileVirtualMachinePowerState(
+				context.Background(),
+				&Meta{Core: client, testMode: true},
+				"vm_failure",
+				false,
+				time.Second,
+			)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func writeVirtualMachinePowerState(
+	w http.ResponseWriter,
+	state core.VirtualMachineStateEnum,
+) {
+	writeTestJSON(w, http.StatusOK, fmt.Sprintf(`{
+		"annotations": [],
+		"virtual_machine": {"id": "vm_power", "state": %q}
+	}`, state))
+}

--- a/internal/v6provider/resource_virtual_machine_power_test.go
+++ b/internal/v6provider/resource_virtual_machine_power_test.go
@@ -94,8 +94,25 @@ func TestVirtualMachinePowerReconciliation(t *testing.T) {
 			states:    []core.VirtualMachineStateEnum{core.Starting, core.Started},
 		},
 		{
+			name:      "starting target on reverts then starts once",
+			poweredOn: true,
+			states: []core.VirtualMachineStateEnum{
+				core.Starting, core.Stopped, core.Stopped, core.Started,
+			},
+			wantAction:   "start",
+			wantEndpoint: "/virtual_machines/virtual_machine/start",
+		},
+		{
 			name:   "shutting down target off waits without duplicate action",
 			states: []core.VirtualMachineStateEnum{core.ShuttingDown, core.Stopped},
+		},
+		{
+			name: "shutting down target off reverts then shuts down once",
+			states: []core.VirtualMachineStateEnum{
+				core.ShuttingDown, core.Started, core.Started, core.Stopped,
+			},
+			wantAction:   "shutdown",
+			wantEndpoint: "/virtual_machines/virtual_machine/shutdown",
 		},
 		{
 			name:      "opposite transition settles before shutdown",
@@ -105,6 +122,20 @@ func TestVirtualMachinePowerReconciliation(t *testing.T) {
 			},
 			wantAction:   "shutdown",
 			wantEndpoint: "/virtual_machines/virtual_machine/shutdown",
+		},
+		{
+			name:      "starting can revert to stopped target without action",
+			poweredOn: false,
+			states: []core.VirtualMachineStateEnum{
+				core.Starting, core.Stopped, core.Stopped,
+			},
+		},
+		{
+			name:      "shutting down can revert to started target without action",
+			poweredOn: true,
+			states: []core.VirtualMachineStateEnum{
+				core.ShuttingDown, core.Started, core.Started,
+			},
 		},
 		{
 			name:      "ambiguous transition settles before start",

--- a/internal/v6provider/resource_virtual_machine_power_test.go
+++ b/internal/v6provider/resource_virtual_machine_power_test.go
@@ -167,7 +167,7 @@ func TestVirtualMachinePowerReconciliation(t *testing.T) {
 						index = len(tt.states) - 1
 					}
 					stateCall++
-					writeVirtualMachinePowerState(w, tt.states[index])
+					writeVirtualMachinePowerState(w, "vm_power", tt.states[index])
 				case r.Method == http.MethodPost &&
 					strings.HasPrefix(
 						r.URL.Path, "/virtual_machines/virtual_machine/",
@@ -220,7 +220,7 @@ func TestVirtualMachinePowerReconciliationRejectsUnsafeStates(t *testing.T) {
 				r *http.Request,
 			) {
 				if r.Method == http.MethodGet {
-					writeVirtualMachinePowerState(w, state)
+					writeVirtualMachinePowerState(w, "vm_power", state)
 					return
 				}
 				actionCalls++
@@ -285,7 +285,7 @@ func TestVirtualMachinePowerReconciliationActionFailures(t *testing.T) {
 			) {
 				switch r.URL.Path {
 				case "/virtual_machines/virtual_machine":
-					writeVirtualMachinePowerState(w, core.Started)
+					writeVirtualMachinePowerState(w, "vm_power", core.Started)
 				case "/virtual_machines/virtual_machine/shutdown":
 					writeTestJSON(w, tt.actionCode, tt.actionBody)
 				case "/tasks/task":
@@ -311,10 +311,11 @@ func TestVirtualMachinePowerReconciliationActionFailures(t *testing.T) {
 
 func writeVirtualMachinePowerState(
 	w http.ResponseWriter,
+	id string,
 	state core.VirtualMachineStateEnum,
 ) {
 	writeTestJSON(w, http.StatusOK, fmt.Sprintf(`{
 		"annotations": [],
-		"virtual_machine": {"id": "vm_power", "state": %q}
-	}`, state))
+		"virtual_machine": {"id": %q, "state": %q}
+	}`, id, state))
 }

--- a/internal/v6provider/resource_virtual_machine_regression_test.go
+++ b/internal/v6provider/resource_virtual_machine_regression_test.go
@@ -334,8 +334,9 @@ func TestVirtualMachineResourceUpdateShutsDownBeforePackageDowngrade(
 ) {
 	t.Parallel()
 
-	vmGetCalls := 0
 	var operations []string
+	shutdownRequested := false
+	packageChanged := false
 	client := newVirtualMachineTestClient(t, func(
 		w http.ResponseWriter,
 		r *http.Request,
@@ -343,15 +344,14 @@ func TestVirtualMachineResourceUpdateShutsDownBeforePackageDowngrade(
 		switch {
 		case r.Method == http.MethodGet &&
 			r.URL.Path == "/virtual_machines/virtual_machine":
-			state := "stopped"
+			state := "started"
 			pkg := "rock-3"
-			if vmGetCalls == 0 {
-				state = "started"
+			if shutdownRequested {
+				state = "stopped"
 			}
-			if vmGetCalls >= 3 {
+			if packageChanged {
 				pkg = "rock-1"
 			}
-			vmGetCalls++
 			writeTestJSON(w, http.StatusOK, `{
 				"annotations": [],
 				"virtual_machine": {
@@ -371,12 +371,14 @@ func TestVirtualMachineResourceUpdateShutsDownBeforePackageDowngrade(
 		case r.Method == http.MethodPost &&
 			r.URL.Path == "/virtual_machines/virtual_machine/shutdown":
 			operations = append(operations, "shutdown")
+			shutdownRequested = true
 			writeTestJSON(w, http.StatusOK, `{
 				"task": {"id": "task_shutdown", "status": "pending"}
 			}`)
 		case r.Method == http.MethodPut &&
 			r.URL.Path == "/virtual_machines/virtual_machine/package":
 			operations = append(operations, "package")
+			packageChanged = true
 			writeTestJSON(w, http.StatusOK, `{
 				"task": {"id": "task_package", "status": "pending"}
 			}`)
@@ -580,7 +582,7 @@ func TestVirtualMachineResourceCreateShutdownFailureKeepsCheckpointedID(
 			}`)
 		case r.Method == http.MethodGet &&
 			r.URL.Path == "/virtual_machines/virtual_machine":
-			writeVirtualMachinePowerState(w, core.Started)
+			writeVirtualMachinePowerState(w, "vm_checkpoint", core.Started)
 		case r.Method == http.MethodPost &&
 			r.URL.Path == "/virtual_machines/virtual_machine/shutdown":
 			writeTestJSON(w, http.StatusForbidden, `{

--- a/internal/v6provider/resource_virtual_machine_regression_test.go
+++ b/internal/v6provider/resource_virtual_machine_regression_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	resourcetimeouts "github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -328,6 +329,304 @@ func TestVirtualMachineResourceUpdateClearsDescriptionWithoutUnknownName(
 	require.Equal(t, "", *patchBody.Properties.Description)
 }
 
+func TestVirtualMachineResourceUpdateShutsDownBeforePackageDowngrade(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	vmGetCalls := 0
+	var operations []string
+	client := newVirtualMachineTestClient(t, func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		switch {
+		case r.Method == http.MethodGet &&
+			r.URL.Path == "/virtual_machines/virtual_machine":
+			state := "stopped"
+			pkg := "rock-3"
+			if vmGetCalls == 0 {
+				state = "started"
+			}
+			if vmGetCalls >= 3 {
+				pkg = "rock-1"
+			}
+			vmGetCalls++
+			writeTestJSON(w, http.StatusOK, `{
+				"annotations": [],
+				"virtual_machine": {
+					"id": "vm_downgrade",
+					"name": "Downgrade VM",
+					"hostname": "downgrade-vm",
+					"fqdn": "downgrade-vm.example.test",
+					"state": "`+state+`",
+					"package": {
+						"id": "vmpkg_test",
+						"permalink": "`+pkg+`"
+					},
+					"ip_addresses": [],
+					"tag_names": []
+				}
+			}`)
+		case r.Method == http.MethodPost &&
+			r.URL.Path == "/virtual_machines/virtual_machine/shutdown":
+			operations = append(operations, "shutdown")
+			writeTestJSON(w, http.StatusOK, `{
+				"task": {"id": "task_shutdown", "status": "pending"}
+			}`)
+		case r.Method == http.MethodPut &&
+			r.URL.Path == "/virtual_machines/virtual_machine/package":
+			operations = append(operations, "package")
+			writeTestJSON(w, http.StatusOK, `{
+				"task": {"id": "task_package", "status": "pending"}
+			}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/tasks/task":
+			writeTestJSON(w, http.StatusOK, `{
+				"task": {"id": "task", "status": "completed"}
+			}`)
+		case r.Method == http.MethodGet &&
+			r.URL.Path ==
+				"/virtual_machines/virtual_machine/network_interfaces":
+			writeTestJSON(w, http.StatusOK, `{
+				"pagination": {"total_pages": 1},
+				"virtual_machine_network_interfaces": []
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	resource := &VirtualMachineResource{M: &Meta{Core: client, testMode: true}}
+	emptyStrings := types.SetValueMust(types.StringType, nil)
+	stateModel := VirtualMachineResourceModel{
+		ID:                types.StringValue("vm_downgrade"),
+		Name:              types.StringValue("Downgrade VM"),
+		Hostname:          types.StringValue("downgrade-vm"),
+		FQDN:              types.StringValue("downgrade-vm.example.test"),
+		State:             types.StringValue("started"),
+		PoweredOn:         types.BoolValue(true),
+		Package:           types.StringValue("rock-3"),
+		DiskTemplate:      types.StringValue("ubuntu-18-04"),
+		IPAddressIDs:      emptyStrings,
+		IPAddresses:       emptyStrings,
+		VirtualNetworkIDs: emptyStrings,
+		Tags:              emptyStrings,
+	}
+	planModel := stateModel
+	planModel.State = types.StringUnknown()
+	planModel.PoweredOn = types.BoolValue(false)
+	planModel.Package = types.StringValue("rock-1")
+
+	state := virtualMachineTestState(t, resource, stateModel)
+	planState := virtualMachineTestState(t, resource, planModel)
+	req := frameworkresource.UpdateRequest{
+		Config: tfsdk.Config(planState),
+		Plan:   tfsdk.Plan(planState),
+		State:  state,
+	}
+	resp := frameworkresource.UpdateResponse{State: tfsdk.State{
+		Schema: state.Schema,
+	}}
+
+	resource.Update(context.Background(), req, &resp)
+
+	require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+	require.Equal(t, []string{"shutdown", "package"}, operations)
+	var got VirtualMachineResourceModel
+	diags := resp.State.Get(context.Background(), &got)
+	require.False(t, diags.HasError(), diags.Errors())
+	require.Equal(t, "rock-1", got.Package.ValueString())
+	require.Equal(t, "stopped", got.State.ValueString())
+	require.False(t, got.PoweredOn.ValueBool())
+}
+
+func TestVirtualMachineResourceUpdatePoweredOnNoDriftQueuesNoPowerAction(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	patchCalls := 0
+	powerCalls := 0
+	client := newVirtualMachineTestClient(t, func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		switch {
+		case r.Method == http.MethodPatch &&
+			r.URL.Path == "/virtual_machines/virtual_machine":
+			patchCalls++
+			writeTestJSON(w, http.StatusOK, `{
+				"virtual_machine": {"id": "vm_started"}
+			}`)
+		case r.Method == http.MethodPost &&
+			strings.HasPrefix(
+				r.URL.Path, "/virtual_machines/virtual_machine/",
+			):
+			powerCalls++
+			http.Error(w, "unexpected power action", http.StatusInternalServerError)
+		case r.Method == http.MethodGet &&
+			r.URL.Path == "/virtual_machines/virtual_machine":
+			writeTestJSON(w, http.StatusOK, `{
+				"annotations": [],
+				"virtual_machine": {
+					"id": "vm_started",
+					"name": "Started VM",
+					"hostname": "started-vm",
+					"description": "New description",
+					"fqdn": "started-vm.example.test",
+					"state": "started",
+					"package": {
+						"id": "vmpkg_test",
+						"permalink": "rock-3"
+					},
+					"ip_addresses": [],
+					"tag_names": []
+				}
+			}`)
+		case r.Method == http.MethodGet &&
+			r.URL.Path ==
+				"/virtual_machines/virtual_machine/network_interfaces":
+			writeTestJSON(w, http.StatusOK, `{
+				"pagination": {"total_pages": 1},
+				"virtual_machine_network_interfaces": []
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	resource := &VirtualMachineResource{M: &Meta{Core: client, testMode: true}}
+	emptyStrings := types.SetValueMust(types.StringType, nil)
+	stateModel := VirtualMachineResourceModel{
+		ID:                types.StringValue("vm_started"),
+		Name:              types.StringValue("Started VM"),
+		Hostname:          types.StringValue("started-vm"),
+		Description:       types.StringValue("Old description"),
+		FQDN:              types.StringValue("started-vm.example.test"),
+		State:             types.StringValue("started"),
+		PoweredOn:         types.BoolValue(true),
+		Package:           types.StringValue("rock-3"),
+		DiskTemplate:      types.StringValue("ubuntu-18-04"),
+		IPAddressIDs:      emptyStrings,
+		IPAddresses:       emptyStrings,
+		VirtualNetworkIDs: emptyStrings,
+		Tags:              emptyStrings,
+	}
+	planModel := stateModel
+	planModel.Description = types.StringValue("New description")
+	planModel.State = types.StringUnknown()
+
+	state := virtualMachineTestState(t, resource, stateModel)
+	planState := virtualMachineTestState(t, resource, planModel)
+	resp := frameworkresource.UpdateResponse{State: tfsdk.State{
+		Schema: state.Schema,
+	}}
+
+	resource.Update(context.Background(), frameworkresource.UpdateRequest{
+		Config: tfsdk.Config(planState),
+		Plan:   tfsdk.Plan(planState),
+		State:  state,
+	}, &resp)
+
+	require.False(t, resp.Diagnostics.HasError(), resp.Diagnostics.Errors())
+	require.Equal(t, 1, patchCalls)
+	require.Zero(t, powerCalls)
+	var got VirtualMachineResourceModel
+	diags := resp.State.Get(context.Background(), &got)
+	require.False(t, diags.HasError(), diags.Errors())
+	require.True(t, got.PoweredOn.ValueBool())
+}
+
+func TestVirtualMachineResourceCreateShutdownFailureKeepsCheckpointedID(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	client := newVirtualMachineTestClient(t, func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		switch {
+		case r.Method == http.MethodGet &&
+			r.URL.Path == "/ip_addresses/ip_address":
+			writeTestJSON(w, http.StatusOK, `{
+				"ip_address": {
+					"id": "ip_test",
+					"network": {"id": "net_test"}
+				}
+			}`)
+		case r.Method == http.MethodPost &&
+			r.URL.Path ==
+				"/organizations/organization/virtual_machines/build_from_spec":
+			writeTestJSON(w, http.StatusCreated, `{
+				"annotations": [],
+				"build": {"id": "vmbuild_test", "state": "pending"},
+				"virtual_machine_build": {
+					"id": "vmbuild_test",
+					"state": "pending"
+				},
+				"task": {"id": "task_build", "status": "pending"},
+				"hostname": "checkpoint-vm"
+			}`)
+		case r.Method == http.MethodGet &&
+			r.URL.Path == "/virtual_machines/builds/virtual_machine_build":
+			writeTestJSON(w, http.StatusOK, `{
+				"virtual_machine_build": {
+					"id": "vmbuild_test",
+					"state": "complete",
+					"virtual_machine": {
+						"id": "vm_checkpoint",
+						"state": "started"
+					}
+				}
+			}`)
+		case r.Method == http.MethodGet &&
+			r.URL.Path == "/virtual_machines/virtual_machine":
+			writeVirtualMachinePowerState(w, core.Started)
+		case r.Method == http.MethodPost &&
+			r.URL.Path == "/virtual_machines/virtual_machine/shutdown":
+			writeTestJSON(w, http.StatusForbidden, `{
+				"error": {
+					"code": "permission_denied",
+					"description": "Cannot shut down"
+				}
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	resource := &VirtualMachineResource{M: &Meta{
+		Core:             client,
+		confDataCenter:   "test-dc",
+		confOrganization: "test-org",
+		testMode:         true,
+	}}
+	model := VirtualMachineResourceModel{
+		Name:              types.StringValue("Checkpoint VM"),
+		Hostname:          types.StringValue("checkpoint-vm"),
+		PoweredOn:         types.BoolValue(false),
+		Package:           types.StringValue("rock-3"),
+		DiskTemplate:      types.StringValue("ubuntu-18-04"),
+		IPAddressIDs:      types.SetValueMust(types.StringType, []attr.Value{types.StringValue("ip_test")}),
+		VirtualNetworkIDs: types.SetValueMust(types.StringType, nil),
+		Tags:              types.SetValueMust(types.StringType, nil),
+	}
+	plan := virtualMachineTestState(t, resource, model)
+	resp := frameworkresource.CreateResponse{State: tfsdk.State{
+		Schema: plan.Schema,
+	}}
+
+	resource.Create(context.Background(), frameworkresource.CreateRequest{
+		Config: tfsdk.Config(plan),
+		Plan:   tfsdk.Plan(plan),
+	}, &resp)
+
+	require.True(t, resp.Diagnostics.HasError())
+	require.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "permission_denied")
+	var got VirtualMachineResourceModel
+	diags := resp.State.Get(context.Background(), &got)
+	require.False(t, diags.HasError(), diags.Errors())
+	require.Equal(t, "vm_checkpoint", got.ID.ValueString())
+}
+
 func TestVirtualMachineGroupDataSourceNotFoundDiagnostic(t *testing.T) {
 	t.Parallel()
 
@@ -599,6 +898,24 @@ func TestVirtualMachineResourceTimeoutsUseBlockSyntax(t *testing.T) {
 	require.Contains(t, timeoutsBlock.Attributes, "create")
 	require.Contains(t, timeoutsBlock.Attributes, "update")
 	require.Contains(t, timeoutsBlock.Attributes, "delete")
+}
+
+func TestVirtualMachineResourcePoweredOnSchemaIsNullableObservation(t *testing.T) {
+	t.Parallel()
+
+	resource := &VirtualMachineResource{}
+	schemaResp := &frameworkresource.SchemaResponse{}
+	resource.Schema(
+		context.Background(),
+		frameworkresource.SchemaRequest{},
+		schemaResp,
+	)
+
+	attribute, ok := schemaResp.Schema.Attributes["powered_on"].(resourceschema.BoolAttribute)
+	require.True(t, ok)
+	require.True(t, attribute.Optional)
+	require.True(t, attribute.Computed)
+	require.Empty(t, attribute.PlanModifiers)
 }
 
 func TestVirtualMachineResourceDiskSizeChangeRequiresReplace(t *testing.T) {

--- a/internal/v6provider/resource_virtual_machine_test.go
+++ b/internal/v6provider/resource_virtual_machine_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/jimeh/undent"
 	"github.com/krystal/go-katapult/next/core"
 )
@@ -537,6 +539,18 @@ func TestAccKatapultVirtualMachine_update(t *testing.T) {
 					}`,
 					name+"-diff", name+"-host-diff",
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectUnknownValue(
+							"katapult_virtual_machine.base",
+							tfjsonpath.New("state"),
+						),
+						plancheck.ExpectUnknownValue(
+							"katapult_virtual_machine.base",
+							tfjsonpath.New("powered_on"),
+						),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKatapultVirtualMachineExists(
 						tt, "katapult_virtual_machine.base",
@@ -577,6 +591,9 @@ func TestAccKatapultVirtualMachine_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"katapult_virtual_machine.base",
 						"network_speed_profile", "10gbps",
+					),
+					resource.TestCheckResourceAttr(
+						"katapult_virtual_machine.base", "powered_on", "true",
 					),
 				),
 			},

--- a/internal/v6provider/testdata/VirtualMachine_power_state.cassette.rand_id
+++ b/internal/v6provider/testdata/VirtualMachine_power_state.cassette.rand_id
@@ -1,0 +1,1 @@
+XxTpTZnRMEc4

--- a/internal/v6provider/testdata/VirtualMachine_power_state.cassette.yaml
+++ b/internal/v6provider/testdata/VirtualMachine_power_state.cassette.yaml
@@ -1,0 +1,6474 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/data_centers/data_center/default_network?data_center%5Bpermalink%5D=uk-lon-01
+    method: GET
+  response:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "196"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:36:53 GMT
+      Etag:
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 956c3d23-7012-41f3-8ae7-21d9b3ad672b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P"},"organization":{"sub_domain":"terraform-acc-test"},"version":"ipv4"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"185-199-221-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "697"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:36:53 GMT
+      Etag:
+      - W/"bc44ed75ff0ddfdc194b77817125f428"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 2c585dcc-1861-43d1-8b2d-fcafff40eb49
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"185-199-221-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "715"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:36:53 GMT
+      Etag:
+      - W/"f4cebb798fdb87cbbbc9b434168dc3ac"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - ac2e0a44-4c32-4143-801b-c0dfbf7b0639
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"185-199-221-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "715"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:36:53 GMT
+      Etag:
+      - W/"f4cebb798fdb87cbbbc9b434168dc3ac"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 03cea938-19a5-4d0b-a247-73af25268950
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"xml":"\u003c?xml version=\"1.0\"
+      encoding=\"UTF-8\"?\u003e\n\u003cVirtualMachineSpec\u003e\u003cDataCenter by=\"permalink\"\u003euk-lon-01\u003c/DataCenter\u003e\u003cResources\u003e\u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\u003c/Resources\u003e\u003cDiskTemplate\u003e\u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\u003cOption
+      key=\"install_agent\"\u003etrue\u003c/Option\u003e\u003c/DiskTemplate\u003e\u003cNetworkInterfaces\u003e\u003cNetworkInterface\u003e\u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\u003cIPAddressAllocation
+      type=\"existing\"\u003e\u003cIPAddress\u003eip_1mm1JmmMV8dU6Cnb\u003c/IPAddress\u003e\u003c/IPAddressAllocation\u003e\u003c/NetworkInterface\u003e\u003c/NetworkInterfaces\u003e\u003cHostname\u003e\u003cHostname\u003etf-acc-test-power-state-XxTpTZnRMEc4-host\u003c/Hostname\u003e\u003c/Hostname\u003e\u003cName\u003etf-acc-test-power-state-XxTpTZnRMEc4\u003c/Name\u003e\u003cAuthorizedKeys\u003e\u003cUsers
+      all=\"yes\"\u003e\u003c/Users\u003e\u003cSSHKeys all=\"yes\"\u003e\u003c/SSHKeys\u003e\u003c/AuthorizedKeys\u003e\u003c/VirtualMachineSpec\u003e"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/organizations/organization/virtual_machines/build_from_spec
+    method: POST
+  response:
+    body: '{"task":{"id":"task_IpH5AsT7cXP4PUfI","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_VS4TjXTCAMlmNPAs","state":"pending"},"virtual_machine_build":{"id":"vmbuild_VS4TjXTCAMlmNPAs","state":"pending"},"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "297"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:36:53 GMT
+      Etag:
+      - W/"212af9283fb4f8aba5d582b5f5517bff"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - a1a121f9-5d80-483a-9a2b-13d5b471c022
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_VS4TjXTCAMlmNPAs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VS4TjXTCAMlmNPAs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-power-state-xxtptznrmec4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-power-state-XxTpTZnRMEc4\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"pending","virtual_machine":null,"created_at":1786714613},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:36:55 GMT
+      Etag:
+      - W/"1eb272ebbc0c738dce0aa37469a6fa69"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - b74bbc06-4ab6-4f8e-bc6f-bad438b1d3bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_VS4TjXTCAMlmNPAs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VS4TjXTCAMlmNPAs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-power-state-xxtptznrmec4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-power-state-XxTpTZnRMEc4\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"pending","virtual_machine":null,"created_at":1786714613},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:00 GMT
+      Etag:
+      - W/"1eb272ebbc0c738dce0aa37469a6fa69"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 1ac077e7-7c3a-4906-b798-ef5604006ed4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_VS4TjXTCAMlmNPAs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VS4TjXTCAMlmNPAs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-power-state-xxtptznrmec4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-power-state-XxTpTZnRMEc4\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1786714613},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:10 GMT
+      Etag:
+      - W/"4295fb8efb9fec4a9eb05da9b25ed92a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 5eafcc9a-0e78-431f-b3f4-0ee8c3312ff0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_VS4TjXTCAMlmNPAs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VS4TjXTCAMlmNPAs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-power-state-xxtptznrmec4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-power-state-XxTpTZnRMEc4\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4","hostname":"tf-acc-test-power-state-xxtptznrmec4-host","fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1786714613},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:20 GMT
+      Etag:
+      - W/"240618542ec93bc351b4bcae33239b95"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 4bb92a40-87d1-41c9-b830-9fc76c55b263
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_VS4TjXTCAMlmNPAs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VS4TjXTCAMlmNPAs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-power-state-xxtptznrmec4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-power-state-XxTpTZnRMEc4\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4","hostname":"tf-acc-test-power-state-xxtptznrmec4-host","fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1786714613},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:30 GMT
+      Etag:
+      - W/"240618542ec93bc351b4bcae33239b95"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 9c707411-9e66-4448-9769-907cb3d92590
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_VS4TjXTCAMlmNPAs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_VS4TjXTCAMlmNPAs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-1\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-power-state-xxtptznrmec4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-power-state-XxTpTZnRMEc4\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4","hostname":"tf-acc-test-power-state-xxtptznrmec4-host","fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1786714613},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:40 GMT
+      Etag:
+      - W/"ba15402f0491242653940a43ebd9b14e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 3dd05c5f-31e5-4b6f-97c7-34e97142f721
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:42 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 8da8b6c8-4113-4877-94a8-c6974eae506f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:42 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - d1f7e32e-e343-4a3b-9c88-7b29bae584db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/shutdown
+    method: POST
+  response:
+    body: '{"task":{"id":"task_Za8vo5hgWG4zzN9q","name":"Shutdown virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "92"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:42 GMT
+      Etag:
+      - W/"81451e4e91e21b2c4ef6aadff87bf88a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 2a292f0a-4cc1-4290-88e0-cd3228f683ec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_Za8vo5hgWG4zzN9q
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Za8vo5hgWG4zzN9q","name":"Shutdown virtual machine","status":"pending","created_at":1786714662,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "166"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:43 GMT
+      Etag:
+      - W/"11b45c569665fe22d076f9e7b3926ad9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - ac440827-5c5c-4c88-bb8d-d8d3fb2573b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_Za8vo5hgWG4zzN9q
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Za8vo5hgWG4zzN9q","name":"Shutdown virtual machine","status":"pending","created_at":1786714662,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "166"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:48 GMT
+      Etag:
+      - W/"11b45c569665fe22d076f9e7b3926ad9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 888d0d53-a352-41b2-a2bd-70d15e3857e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_Za8vo5hgWG4zzN9q
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Za8vo5hgWG4zzN9q","name":"Shutdown virtual machine","status":"pending","created_at":1786714662,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "166"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:37:58 GMT
+      Etag:
+      - W/"11b45c569665fe22d076f9e7b3926ad9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 1cdebe9c-acdf-40da-8afb-459e0a90018a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_Za8vo5hgWG4zzN9q
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Za8vo5hgWG4zzN9q","name":"Shutdown virtual machine","status":"running","created_at":1786714662,"started_at":1786714685,"finished_at":null,"progress":21}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "173"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:08 GMT
+      Etag:
+      - W/"9e8510c57b7777cc4f507beb7b2712ac"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 1d6cf246-e6cb-439a-848c-ec2f64b1b506
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_Za8vo5hgWG4zzN9q
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Za8vo5hgWG4zzN9q","name":"Shutdown virtual machine","status":"completed","created_at":1786714662,"started_at":1786714685,"finished_at":1786714692,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "182"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:18 GMT
+      Etag:
+      - W/"0534816d962c803ec031b46991510363"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 26049ee1-dbcf-4907-a29b-e8e228ea2623
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:19 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 333a3c17-ec11-464d-83f6-013c71e027f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 057e821b-38d9-4b8e-a4c1-d5d435296847
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 0c069d14-741c-4b77-867e-9eab450b583f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 6d5d133a-5914-4e0f-8515-31033f85d574
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 9d6fc540-331b-4f64-ba0b-1c74797e2ae3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 038e1895-eda2-471b-8eb9-adca37fbf587
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 8f9c5ff7-8851-46fd-a45d-f2d0e9d3fd7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 86708d84-8178-4623-b5d4-45c8415f4013
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 963be969-ba76-4fbf-b03a-c503fc8efac9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:20 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 4393bf65-ef57-4ce7-8081-1acb78ba1340
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:21 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 3f63d6f7-2c8c-4a25-b833-52c3af907273
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:21 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 71f5777a-55dc-41de-9d47-11480330a463
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"},"properties":{"tag_names":[]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine
+    method: PATCH
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:21 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 0447caa0-9cb3-43d3-b585-3d871ebadfcc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:21 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - f1ce8c43-4b8c-4d96-ba4c-0dac9f436b02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:21 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 6f3f2a0b-cb87-4b92-98ef-36beb564d264
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:21 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 42e1a3d9-ae12-4cd7-ab11-06df08b1d4c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/start
+    method: POST
+  response:
+    body: '{"task":{"id":"task_7omj4Rwy9R8YrhR8","name":"Start virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "89"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:21 GMT
+      Etag:
+      - W/"43d0fb973d473bcf7bdf10804bf60ef6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 2c752362-5e27-47b0-a2dd-f8f4d76fc217
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_7omj4Rwy9R8YrhR8
+    method: GET
+  response:
+    body: '{"task":{"id":"task_7omj4Rwy9R8YrhR8","name":"Start virtual machine","status":"running","created_at":1786714701,"started_at":1786714702,"finished_at":null,"progress":16}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:22 GMT
+      Etag:
+      - W/"f2177bc917ca851ff2abe4ca112d92e1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - 7930b32f-c9ce-4398-91c6-bc908d95d29b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_7omj4Rwy9R8YrhR8
+    method: GET
+  response:
+    body: '{"task":{"id":"task_7omj4Rwy9R8YrhR8","name":"Start virtual machine","status":"running","created_at":1786714701,"started_at":1786714702,"finished_at":null,"progress":49}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:27 GMT
+      Etag:
+      - W/"2cb2e9b3a273893ffd7e3986207e0948"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 45edcbdf-0b5a-42b8-ab9e-bcef1592e38c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_7omj4Rwy9R8YrhR8
+    method: GET
+  response:
+    body: '{"task":{"id":"task_7omj4Rwy9R8YrhR8","name":"Start virtual machine","status":"completed","created_at":1786714701,"started_at":1786714702,"finished_at":1786714710,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "179"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:37 GMT
+      Etag:
+      - W/"b652c7c16867f8f309e95cef7b79eb26"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 277b06f4-1d9f-4d4b-bf8b-9d41f359655e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:38 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - fe7d4d75-a921-490b-a602-2f5ec3c5454f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:38 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 4f6ece19-1940-4a51-b17c-ae32a71141d1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:38 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 066c26c0-ef26-43ad-97ef-6a19ef9c8008
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:38 GMT
+      Etag:
+      - W/"a59c0a51fd7288bac7eec4582ada4ebf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - fe222e28-4f1c-4917-a153-f5f515dd5d25
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:39 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 3f19148d-3166-41bd-b070-d1eeee48cc61
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:39 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 0c05b703-00c9-4f4e-bafa-741075bc57dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:39 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 8d94f442-80fc-4cf4-923b-a5d4a0c39a78
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:39 GMT
+      Etag:
+      - W/"a59c0a51fd7288bac7eec4582ada4ebf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - 924ac6cc-dd20-4ce7-a850-5dbbe2afb7de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/shutdown
+    method: POST
+  response:
+    body: '{"task":{"id":"task_N5ZmQaOyIwfzovUL","name":"Shutdown virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "92"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:39 GMT
+      Etag:
+      - W/"f3457b127abe564404026f788c258785"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 9bce42e1-67d1-4c93-bc7c-c41b1f22943a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_N5ZmQaOyIwfzovUL
+    method: GET
+  response:
+    body: '{"task":{"id":"task_N5ZmQaOyIwfzovUL","name":"Shutdown virtual machine","status":"running","created_at":1786714719,"started_at":1786714719,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "172"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:40 GMT
+      Etag:
+      - W/"91af83e7eb40927ac99b20ce0beaa82f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - 3d3a937e-9022-4b79-8f60-77764e4cafcb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_N5ZmQaOyIwfzovUL
+    method: GET
+  response:
+    body: '{"task":{"id":"task_N5ZmQaOyIwfzovUL","name":"Shutdown virtual machine","status":"completed","created_at":1786714719,"started_at":1786714719,"finished_at":1786714723,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "182"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:45 GMT
+      Etag:
+      - W/"ef6c6a85a00a77b06604f8d8d6c33b2f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - fa85bd27-d036-4b2e-802f-db09554501f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:46 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 5fe3e7d4-f1a0-48e8-b592-3616c1ba1de1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:46 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - 026889ba-5efc-4504-9edc-c59d687742ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:46 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 625bdbc1-54f8-4775-b6ff-8e593a0ccc2e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:46 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - 73d75817-ec45-4e44-be55-e86d506847d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:46 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - efe5d464-fc17-4231-93d3-a78fa19f0670
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"},"properties":{"tag_names":[]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine
+    method: PATCH
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:47 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - 6bb8990a-c2d3-4760-a2f9-bcd3c1627fc1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:47 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - 1c0337f2-dfb1-4ad5-b96d-b6456358bfb4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:47 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - 075aa690-653e-4ee9-94e3-7d8fa6dac7c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:47 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - 53a1e3dc-6925-401f-9124-e91a81894f9d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/start
+    method: POST
+  response:
+    body: '{"task":{"id":"task_AuN5SvWzfglUOuWp","name":"Start virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "89"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:47 GMT
+      Etag:
+      - W/"2197240cb4599b5eb007cacb7c14b5b5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - 80232f2a-7409-4027-937b-72ff61006955
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_AuN5SvWzfglUOuWp
+    method: GET
+  response:
+    body: '{"task":{"id":"task_AuN5SvWzfglUOuWp","name":"Start virtual machine","status":"running","created_at":1786714727,"started_at":1786714727,"finished_at":null,"progress":16}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:48 GMT
+      Etag:
+      - W/"c479ff1ad223e376258f8fcbbbdbb329"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 22a3f237-23f9-4b4c-9510-ece9d5fa2493
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_AuN5SvWzfglUOuWp
+    method: GET
+  response:
+    body: '{"task":{"id":"task_AuN5SvWzfglUOuWp","name":"Start virtual machine","status":"running","created_at":1786714727,"started_at":1786714727,"finished_at":null,"progress":38}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:38:53 GMT
+      Etag:
+      - W/"3c49d814b2053f8c8bf48dda1070daa3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - 71125dca-6832-48a4-9af5-b94576a912ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_AuN5SvWzfglUOuWp
+    method: GET
+  response:
+    body: '{"task":{"id":"task_AuN5SvWzfglUOuWp","name":"Start virtual machine","status":"completed","created_at":1786714727,"started_at":1786714727,"finished_at":1786714737,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "179"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:03 GMT
+      Etag:
+      - W/"f4c6d7860fe7d45fd8283d317f15144e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 5637e2fc-23e4-41e9-9b75-fa72c99260dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:04 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 446c0d70-3646-4877-8658-be6ba0d6fb8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:04 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - c94b8721-0b68-4ae1-b930-fd45cdc60e9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:04 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - e6b1f010-bb01-4927-9dca-c814e786cd83
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:04 GMT
+      Etag:
+      - W/"a59c0a51fd7288bac7eec4582ada4ebf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - b3b76629-50db-421f-a308-2336bc35d9fb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:04 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 831566c9-ce69-41f6-b568-937177e5fd02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:04 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 501149ee-6580-4608-9a6c-ef910e0af2be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:04 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 94006379-dbf8-4c0b-b58b-e098d5efe8ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:05 GMT
+      Etag:
+      - W/"a59c0a51fd7288bac7eec4582ada4ebf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - a82e1f79-f60a-43e2-8425-041a34fe8aec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:05 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 048b0e81-0156-41f8-992f-ca91390e7f9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:05 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 9526aaf0-216c-404d-b442-3665cc3cc5a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:05 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 82ab8e00-22d9-45c3-b3ed-6f2be87dba6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:05 GMT
+      Etag:
+      - W/"a59c0a51fd7288bac7eec4582ada4ebf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 14dac74f-79c4-4473-a3c5-2f40797b785b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:05 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 8cdb34a5-8380-460f-87cb-1c11a0c7dba0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/shutdown
+    method: POST
+  response:
+    body: '{"task":{"id":"task_TIERFI2iNQgHzMTp","name":"Shutdown virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "92"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:05 GMT
+      Etag:
+      - W/"8bd506b25e7f70e8d0bf78452057350d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - a34b8b80-f897-4a5d-b8f4-d57496db26bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_TIERFI2iNQgHzMTp
+    method: GET
+  response:
+    body: '{"task":{"id":"task_TIERFI2iNQgHzMTp","name":"Shutdown virtual machine","status":"pending","created_at":1786714745,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "166"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:06 GMT
+      Etag:
+      - W/"5fc94c0372201db269f2986d67bb2ebb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 31a72adf-af74-4ae2-bd86-d967870f440f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_TIERFI2iNQgHzMTp
+    method: GET
+  response:
+    body: '{"task":{"id":"task_TIERFI2iNQgHzMTp","name":"Shutdown virtual machine","status":"running","created_at":1786714745,"started_at":1786714747,"finished_at":null,"progress":69}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "173"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:11 GMT
+      Etag:
+      - W/"2073b8cd19224b5b0dd64b4e95b28124"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 388c644b-e27f-4afe-badc-7ac2d336bce9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_TIERFI2iNQgHzMTp
+    method: GET
+  response:
+    body: '{"task":{"id":"task_TIERFI2iNQgHzMTp","name":"Shutdown virtual machine","status":"completed","created_at":1786714745,"started_at":1786714747,"finished_at":1786714752,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "182"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:21 GMT
+      Etag:
+      - W/"f7bf3e801edb21e0d8dcf9cee48f1894"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 3532f823-aebb-4158-af6c-ac8169a65b1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:22 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - d292fd80-df05-4257-ac6e-10644e70d5ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"},"properties":{"tag_names":[]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine
+    method: PATCH
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:22 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - e62e6d0c-b9ab-4c81-bc59-920d2a3e5e86
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:22 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 01a18e96-80a7-4317-9999-18b0ae75ad7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:22 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - c2b70c36-f571-4fc0-9e41-4ceeec038ea6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:22 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - bc91975c-97f8-457f-ad8b-498b07884764
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:22 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - c07e106e-3cf1-4280-8177-c81964a66482
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:22 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - acd69c8f-6fb1-4637-b916-9692375b375b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:23 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 8bc689ed-c93f-4b15-9ca3-1e6077cd4573
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:23 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - d61a2088-bf37-4169-a389-3ccf8cda64fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:23 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 62111864-37b3-42df-831c-127f2889426f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:23 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - e69a2f9e-d822-4d2b-bc0a-f967105368b8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/start
+    method: POST
+  response:
+    body: '{"task":{"id":"task_Z1dlNoGMSfRwkbYw","name":"Start virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "89"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:23 GMT
+      Etag:
+      - W/"1689693d73ca624790bdefa3d28e5702"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - ac076b5d-a560-449c-a282-87c1fcbf1c99
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_Z1dlNoGMSfRwkbYw
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Z1dlNoGMSfRwkbYw","name":"Start virtual machine","status":"running","created_at":1786714763,"started_at":1786714764,"finished_at":null,"progress":16}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:24 GMT
+      Etag:
+      - W/"ec10c053984f10238f96ed5caccb1f0d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 555864b9-0142-4eac-81d3-c34505a1ed3a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_Z1dlNoGMSfRwkbYw
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Z1dlNoGMSfRwkbYw","name":"Start virtual machine","status":"running","created_at":1786714763,"started_at":1786714764,"finished_at":null,"progress":60}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:29 GMT
+      Etag:
+      - W/"1ac8e195354aa69d9cbd3d1a21113079"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - 810e837d-ea34-4e76-a7d1-41cc11bce472
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_Z1dlNoGMSfRwkbYw
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Z1dlNoGMSfRwkbYw","name":"Start virtual machine","status":"completed","created_at":1786714763,"started_at":1786714764,"finished_at":1786714772,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "179"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:39 GMT
+      Etag:
+      - W/"2fa5f8b408c2f650ae86d5139d2cf324"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 1715f605-7525-4af5-b33e-cd50c5bf5802
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:40 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 7a44cc45-cccf-4cc1-921c-afe3a778bc67
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:40 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - 1057b458-84fe-4def-87bd-f7b406bccb93
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:40 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 0abe2a3e-43d9-465b-8684-f45d131c9d69
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:40 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - 795ceb72-bb64-44c5-aad0-9c8f94847b65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:40 GMT
+      Etag:
+      - W/"a59c0a51fd7288bac7eec4582ada4ebf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - 0caf5aea-de4d-4349-bf18-cea59e7f11a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:41 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - a0b4b28c-628b-4340-bd3f-b56a266c85f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/shutdown
+    method: POST
+  response:
+    body: '{"task":{"id":"task_oSLeTYe5xhpX3wc9","name":"Shutdown virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "92"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:41 GMT
+      Etag:
+      - W/"8e77c7cd5dc4d3a55c582b72e7663718"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - f1344d1c-7d55-4d19-ad9a-dcd0344fb652
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_oSLeTYe5xhpX3wc9
+    method: GET
+  response:
+    body: '{"task":{"id":"task_oSLeTYe5xhpX3wc9","name":"Shutdown virtual machine","status":"running","created_at":1786714781,"started_at":1786714781,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "172"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:42 GMT
+      Etag:
+      - W/"9ee59f430b377db9a032ee3b43f6f153"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - cb7c0821-4343-4efd-a9e3-a94b3a5586a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_oSLeTYe5xhpX3wc9
+    method: GET
+  response:
+    body: '{"task":{"id":"task_oSLeTYe5xhpX3wc9","name":"Shutdown virtual machine","status":"completed","created_at":1786714781,"started_at":1786714781,"finished_at":1786714787,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "182"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:47 GMT
+      Etag:
+      - W/"5a24a75a325d11fadbc01985b86dd22c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - 478e8a40-b173-4f3e-89a1-4670dbdb4f95
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - 6fdd7918-63f2-4435-9e2f-6dea9fcbbbea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"},"properties":{"tag_names":[]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine
+    method: PATCH
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 64661fd8-522f-44ab-86d0-0e55cf16f739
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - aa7d942b-8b04-4f19-858b-33b5be0accdd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - 8741009b-c21b-4fcb-b59b-73cfbf5c9884
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "953"
+      X-Request-Id:
+      - d7d0e30c-54b3-42a6-bbd5-e52615c0ce71
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - a16a90e7-1281-46ff-9b44-cc414888c2bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "951"
+      X-Request-Id:
+      - 10997319-7ec2-46f3-b4e7-91d1d3b14175
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "950"
+      X-Request-Id:
+      - 81461fcf-c601-45a0-affd-54c517ac65af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "949"
+      X-Request-Id:
+      - abfe9076-5bc8-4fa8-9b9e-e0393201e9d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - 9c74dd19-b4f6-4ae0-9469-6ad9c2dcb87d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:48 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - f00e076a-2ee9-49e6-8c7a-badbcf803194
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:49 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 24852cd6-ee5a-4ee5-aa8f-0b4332ebc615
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:49 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 0984349a-6ac1-4780-8071-7e9694e4846e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:49 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - 9e6012ce-8ef0-41da-b7ea-a780eaf3fa99
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:49 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - 1aaa026e-c7bf-4568-ac63-27d5b5337a4c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:49 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - b167883e-852d-44fe-a042-70d3649fd504
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:49 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "941"
+      X-Request-Id:
+      - 08ccee0e-15f9-4350-9c65-9902afb528bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:49 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "940"
+      X-Request-Id:
+      - d855568f-f945-4d89-bd7b-1aab31e51005
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:49 GMT
+      Etag:
+      - W/"003e8a57da53267840f3c0b3b7753ffc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "939"
+      X-Request-Id:
+      - dec1dcbb-a7ff-4cb8-88d0-455493dad0cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/start
+    method: POST
+  response:
+    body: '{"task":{"id":"task_k9GxM834k45qc3lv","name":"Start virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "89"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:50 GMT
+      Etag:
+      - W/"268c95ad8dbcf83652f45fa9ef81d811"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "938"
+      X-Request-Id:
+      - a54bb61a-33e9-4511-905a-ec6df46e5710
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_k9GxM834k45qc3lv
+    method: GET
+  response:
+    body: '{"task":{"id":"task_k9GxM834k45qc3lv","name":"Start virtual machine","status":"running","created_at":1786714790,"started_at":1786714790,"finished_at":null,"progress":16}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:51 GMT
+      Etag:
+      - W/"929af2369416851c8c906d12ef7490de"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "937"
+      X-Request-Id:
+      - d13432ac-f058-4926-8ac2-a7a5b529397c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_k9GxM834k45qc3lv
+    method: GET
+  response:
+    body: '{"task":{"id":"task_k9GxM834k45qc3lv","name":"Start virtual machine","status":"running","created_at":1786714790,"started_at":1786714790,"finished_at":null,"progress":38}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:39:56 GMT
+      Etag:
+      - W/"f13299c75e223333955a2e09732a8bef"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "936"
+      X-Request-Id:
+      - 09b0efd8-b290-469d-9409-1c029895a745
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_k9GxM834k45qc3lv
+    method: GET
+  response:
+    body: '{"task":{"id":"task_k9GxM834k45qc3lv","name":"Start virtual machine","status":"completed","created_at":1786714790,"started_at":1786714790,"finished_at":1786714802,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "179"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:06 GMT
+      Etag:
+      - W/"a20f6ce15cfdfd8b5310ffad808467e3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 938ca084-5927-4b40-8dcb-ba39dab90536
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:07 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - f050fd66-eba3-4c33-9202-32c1da49c5c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:07 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 82a8a6d7-0bd9-4b3b-bddb-a3d34b0dffe3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:07 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - a567a339-08ee-496b-ac1b-0ae000b63e8d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:07 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 5d88ddc5-2044-49a4-a609-352238d9cb4c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:07 GMT
+      Etag:
+      - W/"a59c0a51fd7288bac7eec4582ada4ebf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - d4f3b2b4-dcff-4a2f-a937-935eb92a7ab8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "888"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:08 GMT
+      Etag:
+      - W/"a55c80649bd625f1d09cbb25f5b0f0a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 46ca48db-1ec7-4be7-9503-5045362dff74
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:08 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - aef929d5-e08a-4022-95f1-d1063b9ec352
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_4nsz2rtC9sbVN8Wm","name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "521"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:08 GMT
+      Etag:
+      - W/"bd590a406e84f44668088fe9e96ac4c9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 5ddc7188-93e8-49f2-b071-1de6929f3e6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_4nsz2rtC9sbVN8Wm
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_4nsz2rtC9sbVN8Wm","virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp","name":"tf-acc-test-power-state-XxTpTZnRMEc4"},"name":"Public
+      Network on tf-acc-test-power-state-XxTpTZnRMEc4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:00:3f:70:ce:93","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:08 GMT
+      Etag:
+      - W/"a59c0a51fd7288bac7eec4582ada4ebf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 24658bea-2e7a-43be-acc1-f5efc8c64657
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:08 GMT
+      Etag:
+      - W/"e9adff2d965779db553c21af71fc6bb5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 4fa0af3a-173a-4202-9e67-aa2ae217daa0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/stop
+    method: POST
+  response:
+    body: '{"task":{"id":"task_gto8285EpdyTwWau","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:08 GMT
+      Etag:
+      - W/"85f36a0177427c5cb2ac8a24f541ced2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 44ed9d44-278f-4210-b48b-e15070cf05b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_gto8285EpdyTwWau
+    method: GET
+  response:
+    body: '{"task":{"id":"task_gto8285EpdyTwWau","name":"Stop virtual machine","status":"running","created_at":1786714808,"started_at":1786714809,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:09 GMT
+      Etag:
+      - W/"2030bdb4fe4d403ada5e831ad09ac5b5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - c0ef2f3b-e84f-4890-9cb7-eaead04361c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_gto8285EpdyTwWau
+    method: GET
+  response:
+    body: '{"task":{"id":"task_gto8285EpdyTwWau","name":"Stop virtual machine","status":"completed","created_at":1786714808,"started_at":1786714809,"finished_at":1786714811,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:14 GMT
+      Etag:
+      - W/"d19cdfed986aa41806fdf5d69685fe13"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 337e68c3-fc96-4f8e-9928-2ea64d1d0447
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:15 GMT
+      Etag:
+      - W/"377e8d1af10c1f3dbef1bbff8db2a001"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 808fbaef-77a2-4042-9a77-7ff30d22096a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_o1QTzt73bKPpK5Dp"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_qbsTRZimmf9iZbzO","keep_until":1786887615,"object_id":"vm_o1QTzt73bKPpK5Dp","object_type":"VirtualMachine"},"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714632,"description":null,"fqdn":"tf-acc-test-power-state-xxtptznrmec4-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-power-state-xxtptznrmec4-host","id":"vm_o1QTzt73bKPpK5Dp","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_o1QTzt73bKPpK5Dp","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"185-199-221-195.rdns.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-power-state-XxTpTZnRMEc4","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:16 GMT
+      Etag:
+      - W/"5ec2d1fdf3c16cc934c9073deff20cad"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 12ecbb01-35d6-47b8-9e0e-244ff94a9381
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address/unallocate
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:17 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 61dcf8cb-0011-455f-a304-768a1cfa47bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"trash_object":{"id":"trsh_qbsTRZimmf9iZbzO"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_rFyT5mES1LqY30K9","name":"Purge items from trash","status":"pending","created_at":1786714817,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:17 GMT
+      Etag:
+      - W/"64efab02ab30731af0fd889d782b9c50"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 7292de47-52d1-4bed-8e19-c575b0521bd4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bid%5D=trsh_qbsTRZimmf9iZbzO
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_qbsTRZimmf9iZbzO","keep_until":1786887615,"object_id":"vm_o1QTzt73bKPpK5Dp","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:18 GMT
+      Etag:
+      - W/"e5ba21802ee4488b88393a4ab7cee038"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 984fa2d9-e2e7-48b7-843b-3d11f79d9dd5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bid%5D=trsh_qbsTRZimmf9iZbzO
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - b86d0810-70ee-47d7-a725-abbd40463373
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:23 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 05e10edc-1f25-489f-8c1f-c03df8f51ddc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - cf91dcda-f64a-4324-ab1e-4af09cf45b42
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=vm_o1QTzt73bKPpK5Dp
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - 68d0be6c-ca07-47c5-82b5-f2df3076cd98
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:40:23 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - d1cf72ed-9996-4a73-890f-730604de1686
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/internal/v6provider/testdata/VirtualMachine_update_package_downgrade_powered_off.cassette.rand_id
+++ b/internal/v6provider/testdata/VirtualMachine_update_package_downgrade_powered_off.cassette.rand_id
@@ -1,0 +1,1 @@
+O37iyTIyGqqd

--- a/internal/v6provider/testdata/VirtualMachine_update_package_downgrade_powered_off.cassette.yaml
+++ b/internal/v6provider/testdata/VirtualMachine_update_package_downgrade_powered_off.cassette.yaml
@@ -1,0 +1,3681 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/data_centers/data_center/default_network?data_center%5Bpermalink%5D=uk-lon-01
+    method: GET
+  response:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "196"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:17 GMT
+      Etag:
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - c1f3c476-ef58-4993-b98a-2139e089715b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P"},"organization":{"sub_domain":"terraform-acc-test"},"version":"ipv4"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"185-199-221-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "697"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:17 GMT
+      Etag:
+      - W/"bc44ed75ff0ddfdc194b77817125f428"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - b33af308-21d2-4d90-bb88-ac7229f0d74a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"185-199-221-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "715"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:17 GMT
+      Etag:
+      - W/"f4cebb798fdb87cbbbc9b434168dc3ac"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - e807fdc7-9887-4ec6-9b7a-46487e744b7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"185-199-221-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "715"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:17 GMT
+      Etag:
+      - W/"f4cebb798fdb87cbbbc9b434168dc3ac"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 3ff37617-c6e4-462e-8c4c-0906e309823e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"xml":"\u003c?xml version=\"1.0\"
+      encoding=\"UTF-8\"?\u003e\n\u003cVirtualMachineSpec\u003e\u003cDataCenter by=\"permalink\"\u003euk-lon-01\u003c/DataCenter\u003e\u003cResources\u003e\u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\u003c/Resources\u003e\u003cDiskTemplate\u003e\u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\u003cOption
+      key=\"install_agent\"\u003etrue\u003c/Option\u003e\u003c/DiskTemplate\u003e\u003cNetworkInterfaces\u003e\u003cNetworkInterface\u003e\u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\u003cIPAddressAllocation
+      type=\"existing\"\u003e\u003cIPAddress\u003eip_1mm1JmmMV8dU6Cnb\u003c/IPAddress\u003e\u003c/IPAddressAllocation\u003e\u003c/NetworkInterface\u003e\u003c/NetworkInterfaces\u003e\u003cHostname\u003e\u003cHostname\u003etf-acc-test-package-downgrade-power-O37iyTIyGqqd-host\u003c/Hostname\u003e\u003c/Hostname\u003e\u003cName\u003etf-acc-test-package-downgrade-power-O37iyTIyGqqd\u003c/Name\u003e\u003cAuthorizedKeys\u003e\u003cUsers
+      all=\"yes\"\u003e\u003c/Users\u003e\u003cSSHKeys all=\"yes\"\u003e\u003c/SSHKeys\u003e\u003c/AuthorizedKeys\u003e\u003c/VirtualMachineSpec\u003e"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/organizations/organization/virtual_machines/build_from_spec
+    method: POST
+  response:
+    body: '{"task":{"id":"task_z0Eh5VtBNycN5Znj","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_DmkfSvi1rEj3e3Y8","state":"pending"},"virtual_machine_build":{"id":"vmbuild_DmkfSvi1rEj3e3Y8","state":"pending"},"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "309"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:17 GMT
+      Etag:
+      - W/"af625abbb0e5cf7c09114faee2c7a85b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - de998b4d-2f2f-40b0-87ee-1b0e1a37ae99
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_DmkfSvi1rEj3e3Y8
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_DmkfSvi1rEj3e3Y8","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-package-downgrade-power-o37iytiygqqd-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-package-downgrade-power-O37iyTIyGqqd\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1786714877},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:20 GMT
+      Etag:
+      - W/"6f40ca6165dd5ceccdff9ca7090f5e2f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 2e73b886-9616-4a4c-95a7-a7421a36de92
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_DmkfSvi1rEj3e3Y8
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_DmkfSvi1rEj3e3Y8","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-package-downgrade-power-o37iytiygqqd-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-package-downgrade-power-O37iyTIyGqqd\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1786714877},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:25 GMT
+      Etag:
+      - W/"6f40ca6165dd5ceccdff9ca7090f5e2f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 94940f3c-f1c7-43e7-814f-5aca1edf8818
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_DmkfSvi1rEj3e3Y8
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_DmkfSvi1rEj3e3Y8","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-package-downgrade-power-o37iytiygqqd-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-package-downgrade-power-O37iyTIyGqqd\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1786714877},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:35 GMT
+      Etag:
+      - W/"a9051288080cd6cb4862620f9388f5a8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 2192fa00-d1d5-41e9-9437-fdb06007acae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_DmkfSvi1rEj3e3Y8
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_DmkfSvi1rEj3e3Y8","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-package-downgrade-power-o37iytiygqqd-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-package-downgrade-power-O37iyTIyGqqd\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1786714877},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:45 GMT
+      Etag:
+      - W/"a9051288080cd6cb4862620f9388f5a8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - d210d59b-2282-4144-a525-ed2c9bc4db16
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/virtual_machine_build?virtual_machine_build%5Bid%5D=vmbuild_DmkfSvi1rEj3e3Y8
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_DmkfSvi1rEj3e3Y8","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-package-downgrade-power-o37iytiygqqd-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-package-downgrade-power-O37iyTIyGqqd\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","state":"allocating"},"created_at":1786714877},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:55 GMT
+      Etag:
+      - W/"fe3ec7855e89c2d4538c818a1186f231"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 9b2af0bf-9421-4a9d-9a88-0d06d399e780
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"allocating","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:41:57 GMT
+      Etag:
+      - W/"c3bacd06723f175bcd44daf448098fe0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - c6c357f8-1087-4839-a031-198f5401a490
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"starting","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:02 GMT
+      Etag:
+      - W/"0482bed31ad6580817a8110dbf29ebc0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - d075c224-7c43-435c-9b49-35325d9c11c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:12 GMT
+      Etag:
+      - W/"25e84ca45696cf01ced017a4a64e3f5e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - ac74c757-c4f5-4ed5-b520-77df52d8bfb9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:12 GMT
+      Etag:
+      - W/"25e84ca45696cf01ced017a4a64e3f5e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - b9292794-d2aa-41de-b5ff-4039ed7ae873
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:12 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - d31f218d-057d-497b-b226-8143079aa2a2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:12 GMT
+      Etag:
+      - W/"c133fa3b18d097bb773cbe8fd45abc8f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 620a3613-2497-4f56-a129-0f23502434c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "912"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"806c22f852c1ec2fa1693ba2d9f2085d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 52e2d8a1-ab73-49f1-ad08-44bda27e5420
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"25e84ca45696cf01ced017a4a64e3f5e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 7eeddae5-83bd-4b61-a192-4037fd2f04d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - ddef07de-4b16-42d1-bcc0-923c4d401935
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"c133fa3b18d097bb773cbe8fd45abc8f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - d38b11d5-5075-43b3-a00e-dd967fe92f59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "912"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"806c22f852c1ec2fa1693ba2d9f2085d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 6c27f3f9-88d6-4dec-9752-dba89b39e729
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"25e84ca45696cf01ced017a4a64e3f5e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - ee905bf5-5687-46dd-a728-869291cad2ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - f3671097-c110-4835-bfc8-cf84ca46b448
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"c133fa3b18d097bb773cbe8fd45abc8f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - c221d0fc-0882-412e-a1b6-f6899a6a2f25
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"25e84ca45696cf01ced017a4a64e3f5e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 632b85ca-a58a-451e-9e9a-42316de84462
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_packages/virtual_machine_package?virtual_machine_package%5Bpermalink%5D=rock-1
+    method: GET
+  response:
+    body: '{"virtual_machine_package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "329"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"858692638091f36cd41151d389dfdb44"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 6ddbb4de-9387-465b-a48b-2b9326b1517d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"25e84ca45696cf01ced017a4a64e3f5e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 2e1ee4e6-9dc2-42bd-9202-8542fc9e799e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_packages/virtual_machine_package?virtual_machine_package%5Bpermalink%5D=rock-1
+    method: GET
+  response:
+    body: '{"virtual_machine_package":{"id":"vmpkg_dhG25G5SX3HrA5j5","name":"ROCK-1","permalink":"rock-1","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":1,"storage_in_gb":10,"monthly_bandwidth_allowance_in_gb":1024,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "329"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"858692638091f36cd41151d389dfdb44"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 4e745ef4-25b9-4298-a4b9-3d2218c08d3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"25e84ca45696cf01ced017a4a64e3f5e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 03e0c759-c1aa-4bcf-8f9f-db62d86c2154
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_awt3HOkBIicHMo6K"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/shutdown
+    method: POST
+  response:
+    body: '{"task":{"id":"task_3sn8FD7qCVo3ys0o","name":"Shutdown virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "92"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:13 GMT
+      Etag:
+      - W/"7d51cea155b8a4054b407a1928d78470"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 721faf36-903e-4a2b-acea-1c921f0fda93
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_3sn8FD7qCVo3ys0o
+    method: GET
+  response:
+    body: '{"task":{"id":"task_3sn8FD7qCVo3ys0o","name":"Shutdown virtual machine","status":"running","created_at":1786714933,"started_at":1786714934,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "172"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:15 GMT
+      Etag:
+      - W/"4e4e725aec827b9b89687f897433baad"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - baeefb11-32ac-4361-b023-a2e0d2b632b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_3sn8FD7qCVo3ys0o
+    method: GET
+  response:
+    body: '{"task":{"id":"task_3sn8FD7qCVo3ys0o","name":"Shutdown virtual machine","status":"running","created_at":1786714933,"started_at":1786714934,"finished_at":null,"progress":69}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "173"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:20 GMT
+      Etag:
+      - W/"2d4cdba6c63f336e4e1e2e86204455a8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 6b922179-dabb-4523-80e2-9f0a210746df
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_3sn8FD7qCVo3ys0o
+    method: GET
+  response:
+    body: '{"task":{"id":"task_3sn8FD7qCVo3ys0o","name":"Shutdown virtual machine","status":"completed","created_at":1786714933,"started_at":1786714934,"finished_at":1786714940,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "182"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:30 GMT
+      Etag:
+      - W/"f59a6689004646c694035f7c84d29eb9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 9161b60d-9871-4888-83da-5f619fb9282c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:31 GMT
+      Etag:
+      - W/"6cd98d6d9b56fb75225d25111738f2a2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - 2ea52e93-704e-417e-9360-34dacd323411
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":3,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_Eh5LYVKScVHpj7sM","ipv4_addresses":1,"memory_in_gb":3,"monthly_bandwidth_allowance_in_gb":2048,"name":"ROCK-3","permalink":"rock-3","privacy":"public","storage_in_gb":25,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:31 GMT
+      Etag:
+      - W/"6cd98d6d9b56fb75225d25111738f2a2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 5206841e-b093-41eb-bed5-3324be115d7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_awt3HOkBIicHMo6K"},"virtual_machine_package":{"permalink":"rock-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/package
+    method: PUT
+  response:
+    body: '{"task":{"id":"task_sPNVYMFvkLfIzFAF","name":"Change package","status":"pending","created_at":1786714951,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "156"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:31 GMT
+      Etag:
+      - W/"9c622ae020b48f36bf687b65a70f067b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - d545d0b5-2a5b-4ba5-b2c5-233d8b5554ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_sPNVYMFvkLfIzFAF
+    method: GET
+  response:
+    body: '{"task":{"id":"task_sPNVYMFvkLfIzFAF","name":"Change package","status":"pending","created_at":1786714951,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "156"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:32 GMT
+      Etag:
+      - W/"9c622ae020b48f36bf687b65a70f067b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - b65333af-f59d-4d6e-80fe-f818e408706d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_sPNVYMFvkLfIzFAF
+    method: GET
+  response:
+    body: '{"task":{"id":"task_sPNVYMFvkLfIzFAF","name":"Change package","status":"completed","created_at":1786714951,"started_at":1786714952,"finished_at":1786714953,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "172"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:37 GMT
+      Etag:
+      - W/"91f6d41ebb3612f8de3f24d6d3b4d3fa"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - e779f44a-e285-4a33-a616-f6fc1280a03b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_awt3HOkBIicHMo6K"},"properties":{"tag_names":[]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine
+    method: PATCH
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:37 GMT
+      Etag:
+      - W/"7888ccaed23b4ba344d20a17dda4d95d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 8de2195f-83dd-47eb-8972-63edde29f6bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:37 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 93133f48-dc75-408c-b02c-0df5a0d1b850
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:37 GMT
+      Etag:
+      - W/"32d5efcff22146ba8da19e2c56638ecc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - 579377da-525e-443a-b9da-7b0cf9f2f362
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:37 GMT
+      Etag:
+      - W/"7888ccaed23b4ba344d20a17dda4d95d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 796ac779-7727-4065-8e3c-3bde8d1cb205
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:37 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - d3a5ffc5-d1c0-4fc1-8273-4e91ea291a2d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:37 GMT
+      Etag:
+      - W/"32d5efcff22146ba8da19e2c56638ecc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 19d1c632-084d-45bf-b7b2-31ea0a04ca50
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "912"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"806c22f852c1ec2fa1693ba2d9f2085d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - fe8626fa-a6e9-48db-bbe3-5e9e7a8d9046
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"7888ccaed23b4ba344d20a17dda4d95d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - 8807a58d-d2b2-4de5-8c7a-fa9690e2179b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - b33068d3-aee5-4a15-b775-6d0def3b6caa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"32d5efcff22146ba8da19e2c56638ecc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - 9f35528b-8a88-4f94-9ab9-e6dde5ab78b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "912"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"806c22f852c1ec2fa1693ba2d9f2085d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - db32fd09-0247-44e2-8f5f-a3cf43719cf6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"7888ccaed23b4ba344d20a17dda4d95d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - c0f06ee7-649f-4be0-a0cd-a1cc487ecffa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - c6105dc5-22e9-4a8d-a689-7b52c4eea8bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"32d5efcff22146ba8da19e2c56638ecc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - cbcfdd6c-28d8-416b-9750-44b5bd8ff501
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_awt3HOkBIicHMo6K"},"properties":{"tag_names":[]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine
+    method: PATCH
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:38 GMT
+      Etag:
+      - W/"7888ccaed23b4ba344d20a17dda4d95d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - cd2a1ef9-2128-4026-818d-b9884a9a2d1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:39 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - e0d62140-2f92-455b-9a07-327d2e6bc247
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"detached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:39 GMT
+      Etag:
+      - W/"32d5efcff22146ba8da19e2c56638ecc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 6fd326f6-653f-46a4-a07f-1a781c9a1427
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:39 GMT
+      Etag:
+      - W/"7888ccaed23b4ba344d20a17dda4d95d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - e3bd2bb5-e5b4-46f8-a33d-f200562aad5b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_awt3HOkBIicHMo6K"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/start
+    method: POST
+  response:
+    body: '{"task":{"id":"task_RWTYFdiWW7JpPJOq","name":"Start virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "89"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:39 GMT
+      Etag:
+      - W/"c3f74e0548c6aeb28eb2e153ec75ced7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - fa57ba08-dfda-4384-b2fb-50e7e1c45816
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_RWTYFdiWW7JpPJOq
+    method: GET
+  response:
+    body: '{"task":{"id":"task_RWTYFdiWW7JpPJOq","name":"Start virtual machine","status":"running","created_at":1786714959,"started_at":1786714959,"finished_at":null,"progress":16}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:40 GMT
+      Etag:
+      - W/"26f70018ba05632b60a5ac0f3daadbce"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "953"
+      X-Request-Id:
+      - 9c07c6d3-e65f-49d9-bff7-516a0ce149bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_RWTYFdiWW7JpPJOq
+    method: GET
+  response:
+    body: '{"task":{"id":"task_RWTYFdiWW7JpPJOq","name":"Start virtual machine","status":"running","created_at":1786714959,"started_at":1786714959,"finished_at":null,"progress":38}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:45 GMT
+      Etag:
+      - W/"6a485e5399038cf2db83a28f51cab075"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - 44250679-16a2-4150-b8f9-a20e8aa2928e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_RWTYFdiWW7JpPJOq
+    method: GET
+  response:
+    body: '{"task":{"id":"task_RWTYFdiWW7JpPJOq","name":"Start virtual machine","status":"completed","created_at":1786714959,"started_at":1786714959,"finished_at":1786714969,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "179"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:55 GMT
+      Etag:
+      - W/"b6c5f72cfb1d35a0de1e77b1aefe0203"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "951"
+      X-Request-Id:
+      - 6e68c19d-be4d-4c78-8285-3a74eb827cbf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:56 GMT
+      Etag:
+      - W/"74b094cccd93326bd393dee5ecda5798"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "950"
+      X-Request-Id:
+      - 318a2de5-a9f7-4943-a666-6e9dd767dab2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:56 GMT
+      Etag:
+      - W/"74b094cccd93326bd393dee5ecda5798"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "949"
+      X-Request-Id:
+      - b1b9a60d-5ef2-4d30-b4fc-a380ffadcf04
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:56 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - 466c4302-781b-41db-9abc-5641ef04734f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:56 GMT
+      Etag:
+      - W/"c133fa3b18d097bb773cbe8fd45abc8f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - b98b02dc-ac7a-4357-a586-dc2ca1e1969b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"subnet":{"id":"sbnt_YrLWopCUkImX4wo9","address":"185.199.221.0","gateway":"185.199.221.1","mask":24,"billable":true,"version":4},"allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "912"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:56 GMT
+      Etag:
+      - W/"806c22f852c1ec2fa1693ba2d9f2085d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 47345973-7966-4dbd-9a27-72066d4dfd5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:56 GMT
+      Etag:
+      - W/"74b094cccd93326bd393dee5ecda5798"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 6dba8d31-94ac-45fb-afc7-e428a8b232be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zwx7EzJHUnv67XeF","name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195","reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","address_with_mask":"185.199.221.195/24"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "545"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:56 GMT
+      Etag:
+      - W/"d976253e2ef7d4d5eed11ec43f71e554"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - dbcbc7a5-bb22-424f-909c-371527829932
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zwx7EzJHUnv67XeF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zwx7EzJHUnv67XeF","virtual_machine":{"id":"vm_awt3HOkBIicHMo6K","name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd"},"name":"Public
+      Network on tf-acc-test-package-downgrade-power-O37iyTIyGqqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:59:3b:b2:35","state":"attached","ip_addresses":[{"id":"ip_1mm1JmmMV8dU6Cnb","address":"185.199.221.195"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "548"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:56 GMT
+      Etag:
+      - W/"c133fa3b18d097bb773cbe8fd45abc8f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - 2da34cd1-d270-44fd-9967-4c7ada1e9cf3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"started","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:57 GMT
+      Etag:
+      - W/"74b094cccd93326bd393dee5ecda5798"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - 9d9907ac-d8b8-475f-a9b6-09d621777a4c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_awt3HOkBIicHMo6K"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/stop
+    method: POST
+  response:
+    body: '{"task":{"id":"task_0EmXxEQR5u6dkYAo","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:57 GMT
+      Etag:
+      - W/"9d4db359b426a19ee179f4ad1ea7a97b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "941"
+      X-Request-Id:
+      - 09cedafa-28cc-47ba-b3ed-2306aa984b3d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_0EmXxEQR5u6dkYAo
+    method: GET
+  response:
+    body: '{"task":{"id":"task_0EmXxEQR5u6dkYAo","name":"Stop virtual machine","status":"pending","created_at":1786714977,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:42:58 GMT
+      Etag:
+      - W/"d2e0521b4bdbd7a47e2fa82ffbc34665"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "940"
+      X-Request-Id:
+      - dbbd846d-89b0-4024-a942-8d55be29bddf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_0EmXxEQR5u6dkYAo
+    method: GET
+  response:
+    body: '{"task":{"id":"task_0EmXxEQR5u6dkYAo","name":"Stop virtual machine","status":"pending","created_at":1786714977,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:03 GMT
+      Etag:
+      - W/"d2e0521b4bdbd7a47e2fa82ffbc34665"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - dbe6774f-3cfb-46f3-97e7-1fd1b8c912ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/tasks/task?task%5Bid%5D=task_0EmXxEQR5u6dkYAo
+    method: GET
+  response:
+    body: '{"task":{"id":"task_0EmXxEQR5u6dkYAo","name":"Stop virtual machine","status":"completed","created_at":1786714977,"started_at":1786714984,"finished_at":1786714989,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:13 GMT
+      Etag:
+      - W/"1b4f8f989d5f494f30d04959bb00b781"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 1c8f3547-e04a-424b-bd3e-288e10c8a4e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"annotations":[],"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:14 GMT
+      Etag:
+      - W/"7888ccaed23b4ba344d20a17dda4d95d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 767ce9cc-a7d0-4958-8782-c3ec10c752e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"virtual_machine":{"id":"vm_awt3HOkBIicHMo6K"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_34R5BiC4YaUmd41m","keep_until":1786887794,"object_id":"vm_awt3HOkBIicHMo6K","object_type":"VirtualMachine"},"virtual_machine":{"attached_iso":null,"cpu_cores":1,"created_at":1786714885,"description":null,"fqdn":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host.terraform-acc-test.katapult.cloud","gpu_type":null,"gpus":[],"group":null,"hostname":"tf-acc-test-package-downgrade-power-o37iytiygqqd-host","id":"vm_awt3HOkBIicHMo6K","initial_root_password":"[REDACTED]","ip_addresses":[{"address":"185.199.221.195","address_with_mask":"185.199.221.195/24","allocation_id":"vm_awt3HOkBIicHMo6K","allocation_type":"VirtualMachine","id":"ip_1mm1JmmMV8dU6Cnb","label":null,"network":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"default":true,"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public"},"reverse_dns":"185-199-221-195.rdns.katapult.cloud","subnet":{"address":"185.199.221.0","billable":true,"gateway":"185.199.221.1","id":"sbnt_YrLWopCUkImX4wo9","mask":24,"version":4},"vip":false}],"memory_in_gb":1,"name":"tf-acc-test-package-downgrade-power-O37iyTIyGqqd","organization":{"activated_at":1605785692,"address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","billing_name":"terraform-acc-test","country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"country_state":null,"created_at":1605785692,"currency":{"id":"cur_zShCGgjgBz4EbnX1","iso_code":"GBP","name":"British
+      Pound","symbol":"£"},"id":"org_eodfyqFF3YWb2OFC","infrastructure_domain":"terraform-acc-test.katapult.cloud","managed":false,"name":"terraform-acc-test","phone_number":null,"postcode":"ZZ9
+      1LS","sub_domain":"terraform-acc-test","suspended":false,"uuid":"084dea02-7fa9-4a36-bc6a-f5573037fdcd","vat_number":null},"package":{"cpu_cores":1,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"},"icon":null,"id":"vmpkg_dhG25G5SX3HrA5j5","ipv4_addresses":1,"memory_in_gb":1,"monthly_bandwidth_allowance_in_gb":1024,"name":"ROCK-1","permalink":"rock-1","privacy":"public","storage_in_gb":10,"use_dedicated_cpus":false},"state":"stopped","suspended":false,"suspended_at":null,"tag_names":[],"tags":[],"use_dedicated_cpus":false,"zone":{"data_center":{"country":{"eu":false,"id":"ctry_6AO9tYYugvTGnd5b","iso_code2":"GB","iso_code3":"GBR","name":"United
+      Kingdom","time_zone":"Europe/London"},"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:14 GMT
+      Etag:
+      - W/"1276d2bb35ead83d9192afd82cfd1146"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 1f6c1e87-3f60-4bd0-861b-157d97ec0846
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address/unallocate
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:15 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 691f0814-937a-4cfa-b522-c6d415517d9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"trash_object":{"id":"trsh_34R5BiC4YaUmd41m"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_0LxvLOouezz7rq1F","name":"Purge items from trash","status":"pending","created_at":1786714995,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:15 GMT
+      Etag:
+      - W/"78c5af2f6bb2fe046490ea4d663303b0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 6fb5ce80-6a85-4a05-ad85-78026c3da3f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bid%5D=trsh_34R5BiC4YaUmd41m
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_34R5BiC4YaUmd41m","keep_until":1786887794,"object_id":"vm_awt3HOkBIicHMo6K","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:16 GMT
+      Etag:
+      - W/"58f0ea23fda183837ef56d5afc1b33af"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 37bb92d9-916b-49e8-bcb9-8e22568dbab4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bid%5D=trsh_34R5BiC4YaUmd41m
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_34R5BiC4YaUmd41m","keep_until":1786887794,"object_id":"vm_awt3HOkBIicHMo6K","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:21 GMT
+      Etag:
+      - W/"58f0ea23fda183837ef56d5afc1b33af"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 252254ed-cab0-44ba-8d7d-224263009b2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bid%5D=trsh_34R5BiC4YaUmd41m
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_34R5BiC4YaUmd41m","keep_until":1786887794,"object_id":"vm_awt3HOkBIicHMo6K","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:31 GMT
+      Etag:
+      - W/"58f0ea23fda183837ef56d5afc1b33af"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 40bd6938-0a8f-4de7-ad18-9bb1f95b7ab1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bid%5D=trsh_34R5BiC4YaUmd41m
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:41 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 64229e46-f36f-44f2-acbe-8010194619a8
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_1mm1JmmMV8dU6Cnb"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:41 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 054a6f7e-d51a-4cbc-95c0-710224ab0d1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine?virtual_machine%5Bid%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:41 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 27d13a08-5886-4f75-a79d-448150b82b47
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=vm_awt3HOkBIicHMo6K
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:41 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - ff535341-35c8-4b4a-9ea5-7fcc3b69f19d
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_1mm1JmmMV8dU6Cnb
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 14 Aug 2026 13:43:41 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - c86622c0-161c-4d8d-81e4-325dc0ad304f
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
The virtual machine resource currently exposes Katapult's raw VM state but cannot manage whether a VM should be on or off. Existing configurations also need to keep their current behavior instead of silently acquiring power-state ownership.

This adds a nullable `powered_on` attribute:

- omitted keeps power state unmanaged while still reporting the observed value
- `true` reconciles the VM to Katapult's `started` state
- `false` gracefully shuts the VM down and keeps it stopped

Power reconciliation understands Katapult's transitional and failure states, waits for both asynchronous tasks and terminal VM state under one operation deadline, and preserves immediate power-off during deletion. Package downgrades can now be applied to a running VM only when the same configuration explicitly sets `powered_on = false`; shutdown completes before the package change, and restarting remains a separate apply.

The generated documentation and examples describe the opt-in ownership model, create-off behavior, graceful shutdown semantics, and downgrade workflow.

## Testing

- `mise run verify`
- Focused replay of `TestAccKatapultVirtualMachine_power_state`
- Focused replay of `TestAccKatapultVirtualMachine_update_package_downgrade_powered_off`
- Live VCR recordings for both focused acceptance flows
- Existing running-downgrade rejection, stopped-unmanaged downgrade, and v5 migration/import replay coverage
- Deterministic HTTP and Framework regression coverage for transitional and reverted states, action and task failures, unsafe states, plan unknowns, no-drift updates, Create checkpoint retention, and shutdown-before-downgrade ordering

The recorded power lifecycle covers create-off, on/off changes, out-of-band drift correction in both directions, relinquishing ownership, and leaving later drift unmanaged. The recorded package lifecycle proves shutdown-before-downgrade, stable VM identity, and a separate later apply to restart.

---
_Description written on behalf of jimeh by `gpt-5.6-sol` using `T3 Code`._
